### PR TITLE
Feat: 토큰 재발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,63 +1,63 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
-	id 'io.spring.dependency-management' version '1.1.5'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.hf'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 
-	// Spring Jpa
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Spring Jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
-	// Spring Web
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// Spring Actuator
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Spring Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	// Spring Validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // Spring Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// JSON Parser
-	implementation 'org.json:json:20231013'
+    // JSON Parser
+    implementation 'org.json:json:20231013'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// Mysql
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // Mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// Swagger
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
+    // Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/actuator/**",
             "/favicon.ico",
+            "/oauth/token/refresh",
 
             // TODO: 해당 endpoint 확인 후 삭제할 수 있음
             "/login",

--- a/src/main/java/com/hf/healthfriend/auth/constant/SecurityConstants.java
+++ b/src/main/java/com/hf/healthfriend/auth/constant/SecurityConstants.java
@@ -5,7 +5,8 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum SecurityConstants {
-    AUTH_SERVER_COOKIE_KEY("token_auth_server");
+    AUTH_SERVER_COOKIE_KEY("token_auth_server"),
+    REFRESH_TOKEN_COOKIE_KEY("refresh_token");
 
     private final String value;
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -4,7 +4,7 @@ import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.propertyeditor.AuthServerEditor;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
 import com.hf.healthfriend.auth.oauth2.dto.response.OAuth2LoginResponseDto;
-import com.hf.healthfriend.auth.oauth2.tokenprovider.OAuth2TokenSupport;
+import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.dto.request.MemberCreationRequestDto;
 import com.hf.healthfriend.domain.member.dto.response.MemberCreationResponseDto;
 import com.hf.healthfriend.domain.member.service.MemberService;

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -1,0 +1,13 @@
+package com.hf.healthfriend.auth.oauth2.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/oauth/token")
+public class OAuth2TokenController {
+
+//    @GetMapping("/refresh")
+//    public
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -1,13 +1,40 @@
 package com.hf.healthfriend.auth.oauth2.controller;
 
+import com.hf.healthfriend.auth.constant.SecurityConstants;
+import com.hf.healthfriend.auth.oauth2.dto.response.TokenRefreshResponseDto;
+import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequestMapping("/oauth/token")
+@RequiredArgsConstructor
 public class OAuth2TokenController {
+    private final List<OAuth2TokenSupport> tokenSupports;
 
-//    @GetMapping("/refresh")
-//    public
+    @GetMapping("/refresh")
+    public TokenRefreshResponseDto refreshToken(@CookieValue("refresh_token") String refreshToken) {
+        String regrantedAccessToken = null;
+        for (OAuth2TokenSupport tokenSupport : tokenSupports) {
+            try {
+                regrantedAccessToken = tokenSupport.refreshToken(refreshToken);
+            } catch (Exception e) { // TODO: 세밀한 예외 처리
+                log.warn("{}가 처리할 수 없는 Refresh Token", tokenSupport.getClass());
+            }
+        }
+
+        if (regrantedAccessToken == null) {
+            throw new IllegalArgumentException(); // TODO: 임시 예외 / 저 정확한 예외를 던져야 함
+            // TODO: 유효하지 않은 Refresh Token일 경우 401을 던질지 400을 던질지 고민해야 함
+        }
+
+        return new TokenRefreshResponseDto(regrantedAccessToken);
+    }
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/TokenRefreshResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/TokenRefreshResponseDto.java
@@ -1,4 +1,12 @@
 package com.hf.healthfriend.auth.oauth2.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
 public class TokenRefreshResponseDto {
+    private final String accessToken;
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/TokenRefreshResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/TokenRefreshResponseDto.java
@@ -1,0 +1,4 @@
+package com.hf.healthfriend.auth.oauth2.dto.response;
+
+public class TokenRefreshResponseDto {
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
@@ -3,13 +3,11 @@ package com.hf.healthfriend.auth.oauth2.introspect.delegator;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
 import com.hf.healthfriend.auth.oauth2.principal.SingleAuthorityOAuth2Principal;
-import com.hf.healthfriend.auth.oauth2.tokenprovider.GoogleOAuth2TokenSupport;
+import com.hf.healthfriend.auth.oauth2.tokensupport.GoogleOAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
@@ -3,13 +3,11 @@ package com.hf.healthfriend.auth.oauth2.introspect.delegator;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
 import com.hf.healthfriend.auth.oauth2.principal.SingleAuthorityOAuth2Principal;
-import com.hf.healthfriend.auth.oauth2.tokenprovider.KakaoOAuth2TokenSupport;
+import com.hf.healthfriend.auth.oauth2.tokensupport.KakaoOAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/GoogleOAuth2TokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/GoogleOAuth2TokenSupport.java
@@ -1,4 +1,4 @@
-package com.hf.healthfriend.auth.oauth2.tokenprovider;
+package com.hf.healthfriend.auth.oauth2.tokensupport;
 
 public interface GoogleOAuth2TokenSupport extends OAuth2TokenSupport {
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/KakaoOAuth2TokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/KakaoOAuth2TokenSupport.java
@@ -1,4 +1,4 @@
-package com.hf.healthfriend.auth.oauth2.tokenprovider;
+package com.hf.healthfriend.auth.oauth2.tokensupport;
 
 public interface KakaoOAuth2TokenSupport extends OAuth2TokenSupport {
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
@@ -1,4 +1,4 @@
-package com.hf.healthfriend.auth.oauth2.tokenprovider;
+package com.hf.healthfriend.auth.oauth2.tokensupport;
 
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
@@ -14,6 +14,9 @@ public interface OAuth2TokenSupport {
 
     // TODO: 유효하지 않은 토큰일 경우 구체적인 예외 사용
     TokenValidationInfo validateToken(String token) throws RuntimeException;
+
+    // TODO: 유효하지 않은 토큰일 경우 구체적인 예외 사용
+    String refreshToken(String refreshToken) throws RuntimeException;
 
     boolean supports(AuthServer authServer);
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
@@ -1,4 +1,4 @@
-package com.hf.healthfriend.auth.oauth2.tokenprovider;
+package com.hf.healthfriend.auth.oauth2.tokensupport;
 
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
@@ -106,6 +106,26 @@ public class RestTemplateKakaoTokenSupport implements KakaoOAuth2TokenSupport {
             System.out.println(responseBody);
         }
         return now.plus(responseBody.getInt("expires_in"), ChronoUnit.SECONDS);
+    }
+
+    @Override
+    public String refreshToken(String refreshToken) throws RuntimeException {
+        MultiValueMap<String, String> bodyParams = new LinkedMultiValueMap<>();
+        bodyParams.add("grant_type", "refresh_token");
+        bodyParams.add("client_id", this.kakaoClientId);
+        bodyParams.add("refresh_token", refreshToken);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity.post(KAKAO_TOKEN_REQUEST_URL)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(bodyParams);
+
+        JSONObject responseBody = new JSONObject(this.restTemplate.exchange(requestEntity, String.class).getBody());
+
+        if (log.isTraceEnabled()) {
+            log.trace("Response Body:\n{}", responseBody);
+        }
+
+        return responseBody.getString("access_token");
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://localhost:3306/hf?autoReconnect=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     # username과 password는 Local 개발 환경이므로 편의상 공개해 놓음
     # 배포 환경에서는 application-secret.yml 파일에 저장


### PR DESCRIPTION
## 개요

발급받은 Refresh Token을 이용하여 Access Token을 재발급받는 로직을 구현했다.

## 변경사항
- Kakao, Google 각각에 대해 Refresh Token으로 Access Token을 재발급받는 로직 구현

## 참고사항
Refresh Token으로 Access Token을 재발급받을 때 Refresh Token까지 재발급받진 않는다. 좀 더 연구해서 Refresh Token까지 재발급받는 과정이 필요할 것이다.