### PR TITLE
Refactor: 백엔드에서 OAuth 2.0 소셜 로그인 처리

### DIFF
--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import com.hf.healthfriend.auth.filter.AccessDeniedExceptionResolverFilter;
 import com.hf.healthfriend.auth.filter.AuthExceptionHandlerFilter;
 import com.hf.healthfriend.domain.member.constant.Role;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -112,11 +111,11 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8081"));
         // config.addAllowedOriginPattern("http://localhost:3000/reissue");
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowCredentials(true);
-        config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept"));
+        config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept", "Cookie"));
         config.setExposedHeaders(Arrays.asList("Authorization"));
         config.setMaxAge(3600L); // 1시간
 

--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -111,7 +111,7 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8081"));
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080", "http://localhost:8081"));
         // config.addAllowedOriginPattern("http://localhost:3000/reissue");
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowCredentials(true);

--- a/src/main/java/com/hf/healthfriend/auth/constant/CookieConstants.java
+++ b/src/main/java/com/hf/healthfriend/auth/constant/CookieConstants.java
@@ -5,7 +5,9 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum CookieConstants {
-    COOKIE_DURATION_IN_SECONDS("300000");
+    COOKIE_DURATION_IN_SECONDS("300000"),
+    AUTH_SERVER_COOKIE_KEY("token_auth_server"), // 이건 아마 안 쓸 듯
+    REFRESH_TOKEN_COOKIE_KEY("refresh_token");
 
     private final String value;
 

--- a/src/main/java/com/hf/healthfriend/auth/constant/SecurityConstants.java
+++ b/src/main/java/com/hf/healthfriend/auth/constant/SecurityConstants.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum SecurityConstants {
-    AUTH_SERVER_COOKIE_KEY("token_auth_server"),
-    REFRESH_TOKEN_COOKIE_KEY("refresh_token");
+    ;
 
     private final String value;
 

--- a/src/main/java/com/hf/healthfriend/auth/exception/InvalidCodeException.java
+++ b/src/main/java/com/hf/healthfriend/auth/exception/InvalidCodeException.java
@@ -1,0 +1,15 @@
+package com.hf.healthfriend.auth.exception;
+
+/**
+ * OAuth 2.0 Authorization Server로부터 Access Token을 받기 위한 인가 코드가 유효하지 않을 경우 던져지는 Exception
+ */
+public class InvalidCodeException extends RuntimeException {
+
+    public InvalidCodeException(String message) {
+        super(message);
+    }
+
+    public InvalidCodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/hf/healthfriend/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,12 @@
+package com.hf.healthfriend.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidRefreshTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -25,9 +25,7 @@ import java.util.Map;
  * 받아와 요청이 들어온 클라이언트에 전달(Response)한다.
  *
  * @author PGD
- * @deprecated 토큰을 받는 요청을 프론트엔드에서 처리하기로 협의했으므로 이 컨트롤러는 필요없게 됨
  */
-@Deprecated
 @Slf4j
 @RestController
 @RequestMapping("/oauth/code")

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -8,7 +8,15 @@ import com.hf.healthfriend.auth.oauth2.dto.response.OAuth2LoginResponseDto;
 import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.service.MemberService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
+import com.hf.healthfriend.global.spec.ApiErrorResponse;
+import com.hf.healthfriend.global.spec.schema.OAuth2LoginResponseSchema;
 import com.hf.healthfriend.global.util.HttpCookieUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -58,12 +66,72 @@ public class OAuth2RedirectionController {
         binder.registerCustomEditor(AuthServer.class, AuthServerEditor.getInstance());
     }
 
+    @Operation(summary = "카카오 로그인 Redirect URI")
+    @ApiResponses({
+            @ApiResponse(
+                    description = "카카오 로그인 성공 및 Access Token, Refresh Token, email 반환",
+                    responseCode = "200",
+                    headers = @Header(
+                            name = "Set-Cookie",
+                            description = "Refresh Token을 담은 HTTP-only, Secure, Same-site: None 쿠키"
+                    ),
+                    content = @Content(schema = @Schema(implementation = OAuth2LoginResponseSchema.class))
+            ),
+            @ApiResponse(
+                    description = "유효하지 않은 인가코드로 인한 카카오 로그인 실패",
+                    responseCode = "401",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ApiErrorResponse.class,
+                                    example = """
+                                            {
+                                                "statusCode": 401,
+                                                "statusCodeSeries": 4,
+                                                "errorCode": 102,
+                                                "errorName": "INVALID_CODE",
+                                                "message": "유효하지 않은 인가코드입니다"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/kakao")
     public ResponseEntity<ApiBasicResponse<OAuth2LoginResponseDto>> get(@RequestParam("code") String code, HttpServletRequest request) {
         log.info("Kakao Login has been requested");
         return doTheSameThing(AuthServer.KAKAO, code, request.getRequestURL().toString());
     }
 
+    @Operation(summary = "구글 로그인 Redirect URI")
+    @ApiResponses({
+            @ApiResponse(
+                    description = "구글 로그인 성공 및 Access Token, Refresh Token, email 반환",
+                    responseCode = "200",
+                    headers = @Header(
+                            name = "Set-Cookie",
+                            description = "Refresh Token을 담은 HTTP-only, Secure, Same-site: None 쿠키"
+                    ),
+                    content = @Content(schema = @Schema(implementation = OAuth2LoginResponseSchema.class))
+            ),
+            @ApiResponse(
+                    description = "유효하지 않은 인가코드로 인한 구글 로그인 실패",
+                    responseCode = "401",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ApiErrorResponse.class,
+                                    example = """
+                                            {
+                                                "statusCode": 401,
+                                                "statusCodeSeries": 4,
+                                                "errorCode": 102,
+                                                "errorName": "INVALID_CODE",
+                                                "message": "유효하지 않은 인가코드입니다"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     @GetMapping("/google")
     public ResponseEntity<ApiBasicResponse<OAuth2LoginResponseDto>> getGoogle(@RequestParam("code") String code, HttpServletRequest request) {
         log.info("Google Login has been requested");

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -1,18 +1,19 @@
 package com.hf.healthfriend.auth.oauth2.controller;
 
+import com.hf.healthfriend.auth.constant.CookieConstants;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.propertyeditor.AuthServerEditor;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
 import com.hf.healthfriend.auth.oauth2.dto.response.OAuth2LoginResponseDto;
 import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
-import com.hf.healthfriend.domain.member.dto.request.MemberCreationRequestDto;
-import com.hf.healthfriend.domain.member.dto.response.MemberCreationResponseDto;
 import com.hf.healthfriend.domain.member.service.MemberService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
 import com.hf.healthfriend.global.util.HttpCookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
@@ -77,8 +78,13 @@ public class OAuth2RedirectionController {
 
         boolean memberExists = this.memberService.isMemberExists(grantedTokenInfo.getEmail());
 
+        ResponseCookie refreshTokenCookie =
+                this.cookieUtils.buildResponseCookie(CookieConstants.REFRESH_TOKEN_COOKIE_KEY.getString(),
+                        grantedTokenInfo.getRefreshToken());
+
         // TODO: 302 Redirection Status를 set 해야 할 듯
         return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .body(ApiBasicResponse.of(new OAuth2LoginResponseDto(!memberExists, grantedTokenInfo), HttpStatus.OK));
     }
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -14,6 +14,7 @@ import com.hf.healthfriend.global.util.HttpCookieUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -81,17 +82,16 @@ public class OAuth2RedirectionController {
                     description = "유효하지 않은 인가코드로 인한 카카오 로그인 실패",
                     responseCode = "401",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ApiErrorResponse.class,
-                                    example = """
-                                            {
-                                                "statusCode": 401,
-                                                "statusCodeSeries": 4,
-                                                "errorCode": 102,
-                                                "errorName": "INVALID_CODE",
-                                                "message": "유효하지 않은 인가코드입니다"
-                                            }
-                                            """
+                            schema = @Schema(implementation = ApiErrorResponse.class),
+                            examples = @ExampleObject("""
+                                    {
+                                        "statusCode": 401,
+                                        "statusCodeSeries": 4,
+                                        "errorCode": 102,
+                                        "errorName": "INVALID_CODE",
+                                        "message": "유효하지 않은 인가코드입니다"
+                                    }
+                                    """
                             )
                     )
             )
@@ -117,17 +117,16 @@ public class OAuth2RedirectionController {
                     description = "유효하지 않은 인가코드로 인한 구글 로그인 실패",
                     responseCode = "401",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ApiErrorResponse.class,
-                                    example = """
-                                            {
-                                                "statusCode": 401,
-                                                "statusCodeSeries": 4,
-                                                "errorCode": 102,
-                                                "errorName": "INVALID_CODE",
-                                                "message": "유효하지 않은 인가코드입니다"
-                                            }
-                                            """
+                            schema = @Schema(implementation = ApiErrorResponse.class),
+                            examples = @ExampleObject("""
+                                    {
+                                        "statusCode": 401,
+                                        "statusCodeSeries": 4,
+                                        "errorCode": 102,
+                                        "errorName": "INVALID_CODE",
+                                        "message": "유효하지 않은 인가코드입니다"
+                                    }
+                                    """
                             )
                     )
             )

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -1,6 +1,6 @@
 package com.hf.healthfriend.auth.oauth2.controller;
 
-import com.hf.healthfriend.auth.constant.SecurityConstants;
+import com.hf.healthfriend.auth.constant.CookieConstants;
 import com.hf.healthfriend.auth.oauth2.dto.request.WrappingRefreshTokenWithCookieRequestDto;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenRefreshResponseDto;
 import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
@@ -27,14 +27,15 @@ public class OAuth2TokenController {
     public ResponseEntity<ApiBasicResponse<Void>> wrapWithCookie(@RequestBody WrappingRefreshTokenWithCookieRequestDto dto) {
         var refreshToken = dto.getRefreshToken();
         var responseCookie =
-                this.httpCookieUtils.buildResponseCookie(SecurityConstants.REFRESH_TOKEN_COOKIE_KEY.get(), refreshToken);
+                this.httpCookieUtils.buildResponseCookie(CookieConstants.REFRESH_TOKEN_COOKIE_KEY.getString(), refreshToken);
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(ApiBasicResponse.of(HttpStatus.OK, "Refresh Token에 쿠키 저장 완료"));
     }
 
     @GetMapping("/refresh")
-    public TokenRefreshResponseDto refreshToken(@CookieValue("refresh_token") String refreshToken) {
+    public ResponseEntity<ApiBasicResponse<TokenRefreshResponseDto>> refreshToken(
+            @CookieValue("refresh_token") String refreshToken) {
         String regrantedAccessToken = null;
         for (OAuth2TokenSupport tokenSupport : tokenSupports) {
             try {
@@ -49,6 +50,6 @@ public class OAuth2TokenController {
             // TODO: 유효하지 않은 Refresh Token일 경우 401을 던질지 400을 던질지 고민해야 함
         }
 
-        return new TokenRefreshResponseDto(regrantedAccessToken);
+        return ResponseEntity.ok(ApiBasicResponse.of(new TokenRefreshResponseDto(regrantedAccessToken), HttpStatus.OK));
     }
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -11,6 +11,7 @@ import com.hf.healthfriend.global.spec.schema.TokenRefreshResponseSchema;
 import com.hf.healthfriend.global.util.HttpCookieUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -51,36 +52,36 @@ public class OAuth2TokenController {
                     description = "Access Token 재발급 성공",
                     responseCode = "200",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = TokenRefreshResponseSchema.class,
-                                    example = """
+                            schema = @Schema(implementation = TokenRefreshResponseSchema.class),
+                            examples = {
+                                    @ExampleObject("""
                                             {
                                                 "statusCode": 200,
-                                                "statusCodeSeries: 2,
+                                                "statusCodeSeries": 2,
                                                 "message": null,
                                                 "content": {
                                                     "accessToken": "fawoigh42ihsioahoidasasodifh..."
                                                 }
                                             }
                                             """
-                            )
+                                    )
+                            }
                     )
             ),
             @ApiResponse(
-                    description = "유효하지 않은 Refresh Token으로 인한 Acces Token 재발급 실패",
+                    description = "유효하지 않은 Refresh Token으로 인한 Access Token 재발급 실패",
                     responseCode = "401",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ApiErrorResponse.class,
-                                    example = """
-                                            {
-                                                "statusCode": 401,
-                                                "statusCodeSeries" 4,
-                                                "errorCode": 103,
-                                                "errorName": "INVALID_REFRESH_TOKEN",
-                                                "message": "유효하지 않은 Refresh Token입니다"
-                                            }
-                                            """
+                            schema = @Schema(implementation = ApiErrorResponse.class),
+                            examples = @ExampleObject("""
+                                    {
+                                        "statusCode": 401,
+                                        "statusCodeSeries": 4,
+                                        "errorCode": 103,
+                                        "errorName": "INVALID_REFRESH_TOKEN",
+                                        "message": "유효하지 않은 Refresh Token입니다"
+                                    }
+                                    """
                             )
                     )
             )

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/exceptionhandler/OAuth2ExceptionHandler.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/exceptionhandler/OAuth2ExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.auth.oauth2.controller.exceptionhandler;
 
 import com.hf.healthfriend.auth.exception.InvalidCodeException;
+import com.hf.healthfriend.auth.exception.InvalidRefreshTokenException;
 import com.hf.healthfriend.global.spec.ApiErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.hf.healthfriend.global.exception.ErrorCode.INVALID_CODE;
+import static com.hf.healthfriend.global.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 
 @Slf4j
 @RestControllerAdvice
@@ -34,6 +36,31 @@ public class OAuth2ExceptionHandler {
                         .errorCode(INVALID_CODE.code())
                         .errorName(INVALID_CODE.name())
                         .message(INVALID_CODE.message())
+                        .build(),
+                HttpStatus.UNAUTHORIZED
+        );
+    }
+
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    public ResponseEntity<ApiErrorResponse> invalidRefreshTokenException(InvalidRefreshTokenException e) {
+        log.error("""
+                InvalidRefreshTokenException
+                Error Code: {}
+                HTTP Status: {}
+                message: {}
+                """,
+                INVALID_REFRESH_TOKEN.code(),
+                HttpStatus.UNAUTHORIZED.value(),
+                INVALID_REFRESH_TOKEN.message(),
+                e);
+
+        return new ResponseEntity<>(
+                ApiErrorResponse.builder()
+                        .statusCode(HttpStatus.UNAUTHORIZED.value())
+                        .statusCodeSeries(HttpStatus.UNAUTHORIZED.series().value())
+                        .errorCode(INVALID_REFRESH_TOKEN.code())
+                        .errorName(INVALID_REFRESH_TOKEN.name())
+                        .message(INVALID_REFRESH_TOKEN.message())
                         .build(),
                 HttpStatus.UNAUTHORIZED
         );

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/exceptionhandler/OAuth2ExceptionHandler.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/exceptionhandler/OAuth2ExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.hf.healthfriend.auth.oauth2.controller.exceptionhandler;
+
+import com.hf.healthfriend.auth.exception.InvalidCodeException;
+import com.hf.healthfriend.global.spec.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.hf.healthfriend.global.exception.ErrorCode.INVALID_CODE;
+
+@Slf4j
+@RestControllerAdvice
+public class OAuth2ExceptionHandler {
+
+    @ExceptionHandler(InvalidCodeException.class)
+    public ResponseEntity<ApiErrorResponse> invalidCodeException(InvalidCodeException e) {
+        log.error("""
+                InvalidCodeException
+                Error Code: {}
+                HTTP Status: {}
+                message: {}
+                """,
+                INVALID_CODE.code(),
+                HttpStatus.UNAUTHORIZED.value(),
+                INVALID_CODE.message(),
+                e);
+
+        return new ResponseEntity<>(
+                ApiErrorResponse.builder()
+                        .statusCode(HttpStatus.UNAUTHORIZED.value())
+                        .statusCodeSeries(HttpStatus.UNAUTHORIZED.series().value())
+                        .errorCode(INVALID_CODE.code())
+                        .errorName(INVALID_CODE.name())
+                        .message(INVALID_CODE.message())
+                        .build(),
+                HttpStatus.UNAUTHORIZED
+        );
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/OAuth2LoginResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/dto/response/OAuth2LoginResponseDto.java
@@ -1,6 +1,5 @@
 package com.hf.healthfriend.auth.oauth2.dto.response;
 
-import com.hf.healthfriend.domain.member.dto.response.MemberCreationResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -9,6 +8,6 @@ import lombok.ToString;
 @Getter
 @ToString
 public class OAuth2LoginResponseDto {
-    MemberCreationResponseDto memberCreationInfo;
-    GrantedTokenInfo grantedTokenInfo;
+    private boolean newMember;
+    private GrantedTokenInfo grantedTokenInfo;
 }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.auth.oauth2.tokensupport;
 
+import com.hf.healthfriend.auth.exception.InvalidCodeException;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
@@ -9,8 +10,15 @@ import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
  */
 public interface OAuth2TokenSupport {
 
-    // TODO: 인증 실패 시 구체적인 예외 사용
-    GrantedTokenInfo grantToken(String code, String redirectUri) throws RuntimeException;
+    /**
+     * Redirection URI로 전송된 인가코드를 바탕으로 OAuth 2.0 Authorization Server로부터 Access Token과 Refresh Token,
+     * 그리고 email과 같은 사용자 정보를 가져온다.
+     * @param code 인가 코드
+     * @param redirectUri Redirect URI
+     * @return Access Token, Refresh Token, email이 정보가 담긴 인스턴스
+     * @throws InvalidCodeException 인가 코드가 유효하지 않을 경우
+     */
+    GrantedTokenInfo grantToken(String code, String redirectUri) throws InvalidCodeException;
 
     // TODO: 유효하지 않은 토큰일 경우 구체적인 예외 사용
     TokenValidationInfo validateToken(String token) throws RuntimeException;

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/OAuth2TokenSupport.java
@@ -9,7 +9,6 @@ import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
  */
 public interface OAuth2TokenSupport {
 
-    @Deprecated
     // TODO: 인증 실패 시 구체적인 예외 사용
     GrantedTokenInfo grantToken(String code, String redirectUri) throws RuntimeException;
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
@@ -39,7 +39,6 @@ public class RestTemplateGoogleTokenSupport implements GoogleOAuth2TokenSupport 
         this.clientSecret = clientSecret;
     }
 
-    @Deprecated
     @Override
     public GrantedTokenInfo grantToken(String code, String redirectUri) {
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.auth.oauth2.tokensupport;
 
+import com.hf.healthfriend.auth.exception.InvalidCodeException;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -40,12 +42,19 @@ public class RestTemplateGoogleTokenSupport implements GoogleOAuth2TokenSupport 
     }
 
     @Override
-    public GrantedTokenInfo grantToken(String code, String redirectUri) {
+    public GrantedTokenInfo grantToken(String code, String redirectUri) throws InvalidCodeException {
 
         LocalDateTime recordNow = LocalDateTime.now();
 
+        ResponseEntity<String> responseEntity;
+        try {
+            responseEntity =
+                    this.restTemplate.exchange(buildRequestEntityForToken(code, redirectUri), String.class);
+        } catch (Exception e) {
+            throw new InvalidCodeException("유효하지 않은 인가 코드: " + code, e);
+        }
         JSONObject responseBody =
-                new JSONObject(this.restTemplate.exchange(buildRequestEntityForToken(code, redirectUri), String.class).getBody());
+                new JSONObject(responseEntity.getBody());
 
         log.trace("Full Response Body\n{}", responseBody);
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.auth.oauth2.tokensupport;
 
+import com.hf.healthfriend.auth.exception.InvalidCodeException;
 import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
 import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
 import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
@@ -43,7 +44,7 @@ public class RestTemplateKakaoTokenSupport implements KakaoOAuth2TokenSupport {
     }
 
     @Override
-    public GrantedTokenInfo grantToken(String code, String redirectUri) throws RuntimeException {
+    public GrantedTokenInfo grantToken(String code, String redirectUri) throws InvalidCodeException {
         log.debug("redirectUri={}", redirectUri);
         LocalDateTime recordNow = LocalDateTime.now();
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
@@ -48,8 +48,16 @@ public class RestTemplateKakaoTokenSupport implements KakaoOAuth2TokenSupport {
         log.debug("redirectUri={}", redirectUri);
         LocalDateTime recordNow = LocalDateTime.now();
 
+        ResponseEntity<String> responseEntity;
+        try {
+            responseEntity =
+                    this.restTemplate.exchange(buildTokenRequestEntity(code, redirectUri), String.class);
+        } catch (Exception e) {
+            throw new InvalidCodeException("유효하지 않은 인가 코드: " + code, e);
+        }
+
         JSONObject responseBody =
-                new JSONObject(this.restTemplate.exchange(buildTokenRequestEntity(code, redirectUri), String.class).getBody());
+                new JSONObject(responseEntity.getBody());
 
         String accessToken = responseBody.getString("access_token");
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
@@ -42,7 +42,6 @@ public class RestTemplateKakaoTokenSupport implements KakaoOAuth2TokenSupport {
         this.kakaoClientId = kakaoClientId;
     }
 
-    @Deprecated
     @Override
     public GrantedTokenInfo grantToken(String code, String redirectUri) throws RuntimeException {
         log.debug("redirectUri={}", redirectUri);

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.member.dto.request;
 
 import com.hf.healthfriend.domain.member.constant.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -12,14 +13,32 @@ import java.time.LocalDate;
 @ToString
 @EqualsAndHashCode
 public class MemberCreationRequestDto {
+
+    @Schema(description = "생성할 회원의 ID. 소셜 로그인일 경우 id와 email은 같다. email은 id로 설정된다.")
     private String id;
+
     private String nickname;
+
+    @Schema(description = "yyyy-mm-dd 형식 ex) 2017-08-09")
     private LocalDate birthDate;
+
+    @Schema(description = "성별 - 남자 = MALE / 여자 = FEMALE")
     private Gender gender;
+    
     private String introduction;
+
+    @Schema(description = "운동 레벨 - 새싹 = BEGINNER / 고수 = ADVANCED")
     private FitnessLevel fitnessLevel;
+
+    @Schema(description = "운동할 때 주로 누구랑? - 소규모형 = SMALL / 그룹형 = GROUP")
     private CompanionStyle companionStyle;
+
+    @Schema(description = "운동할 때 나는 평소? - 의욕만렙형 = EAGER / 귀차니즘형 = LAZY")
     private FitnessEagerness fitnessEagerness;
+
+    @Schema(description = "나의 운동 목적은? - 벌크업 = BULK_UP / 러닝러닝 = RUNNING")
     private FitnessObjective fitnessObjective;
+
+    @Schema(description = "주로 하고 있는 운동은? - 고강도 운동 위주 = HIGH_STRESS / 기능성 피트니스 위주 = FUNCTIONAL")
     private FitnessKind fitnessKind;
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberCreationResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberCreationResponseDto.java
@@ -2,6 +2,7 @@ package com.hf.healthfriend.domain.member.dto.response;
 
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -12,18 +13,35 @@ import java.time.LocalDateTime;
 @Getter
 @ToString
 public class MemberCreationResponseDto {
+
+    @Schema(description = "생성된 회원의 ID. 소셜 로그인일 경우 memberId와 email은 같다.")
     private final String memberId;
+
+    @Schema(description = "생성된 회원의 Email. 소셜 로그인일 경우 memberId와 email은 같다.")
     private final String email;
+
+    @Schema(description = "권한 설정 때 사용하는 Role. 기본적으로 Role은 자동 지정", defaultValue = "ROLE_MEMBER")
     private final String role;
+
     private final LocalDateTime creationTime;
     private final String nickname;
     private final LocalDate birthDate;
     private final Gender gender;
     private final String introduction;
+
+    @Schema(description = "운동 레벨 - 새싹 = BEGINNER / 고수 = ADVANCED")
     private final FitnessLevel fitnessLevel;
+
+    @Schema(description = "운동할 때 주로 누구랑? - 소규모형 = SMALL / 그룹형 = GROUP")
     private final CompanionStyle companionStyle;
+
+    @Schema(description = "운동할 때 나는 평소? - 의욕만렙형 = EAGER / 귀차니즘형 = LAZY")
     private final FitnessEagerness fitnessEagerness;
+
+    @Schema(description = "나의 운동 목적은? - 벌크업 = BULK_UP / 러닝러닝 = RUNNING")
     private final FitnessObjective fitnessObjective;
+
+    @Schema(description = "주로 하고 있는 운동은? - 고강도 운동 위주 = HIGH_STRESS / 기능성 피트니스 위주 = FUNCTIONAL")
     private final FitnessKind fitnessKind;
 
     public static MemberCreationResponseDto of(Member member) {

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -43,6 +43,10 @@ public class MemberService {
         return MemberCreationResponseDto.of(saved);
     }
 
+    public boolean isMemberExists(String memberId) {
+        return this.memberRepository.existsById(memberId);
+    }
+
     public MemberDto findMember(String memberId) throws MemberNotFoundException {
         return MemberDto.of(this.memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId)));

--- a/src/main/java/com/hf/healthfriend/global/exception/ErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 public enum ErrorCode {
     UNAUTHENTICATED(100, "인증되지 않은 사용자입니다"),
     UNAUTHORIZED(101, "허용되지 않은 접근입니다"),
+    INVALID_CODE(102, "유효하지 않은 인가코드입니다"),
 
     MEMBER_OF_THE_MEMBER_ID_NOT_FOUND(200, "memberId에 해당하는 회원이 없습니다"),
     MEMBER_ALREADY_EXISTS(201, "이미 존재하는 회원입니다");

--- a/src/main/java/com/hf/healthfriend/global/exception/ErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     UNAUTHENTICATED(100, "인증되지 않은 사용자입니다"),
     UNAUTHORIZED(101, "허용되지 않은 접근입니다"),
     INVALID_CODE(102, "유효하지 않은 인가코드입니다"),
+    INVALID_REFRESH_TOKEN(103, "유효하지 않은 Refresh Token입니다"),
 
     MEMBER_OF_THE_MEMBER_ID_NOT_FOUND(200, "memberId에 해당하는 회원이 없습니다"),
     MEMBER_ALREADY_EXISTS(201, "이미 존재하는 회원입니다");

--- a/src/main/java/com/hf/healthfriend/global/spec/schema/MemberCreationResponseSchema.java
+++ b/src/main/java/com/hf/healthfriend/global/spec/schema/MemberCreationResponseSchema.java
@@ -2,6 +2,31 @@ package com.hf.healthfriend.global.spec.schema;
 
 import com.hf.healthfriend.domain.member.dto.response.MemberCreationResponseDto;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "회원 생성 응답")
 public class MemberCreationResponseSchema extends ApiBasicResponse<MemberCreationResponseDto> {
+
+    @Schema(description = "응답코드", defaultValue = "201")
+    @Override
+    public int getStatusCode() {
+        return super.getStatusCode();
+    }
+
+    @Schema(description = "응답코드 시리즈", defaultValue = "2")
+    @Override
+    public int getStatusCodeSeries() {
+        return super.getStatusCodeSeries();
+    }
+
+    @Schema(description = "메세지는 null", defaultValue = "null")
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    @Override
+    public MemberCreationResponseDto getContent() {
+        return super.getContent();
+    }
 }

--- a/src/main/java/com/hf/healthfriend/global/spec/schema/OAuth2LoginResponseSchema.java
+++ b/src/main/java/com/hf/healthfriend/global/spec/schema/OAuth2LoginResponseSchema.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.global.spec.schema;
+
+import com.hf.healthfriend.auth.oauth2.dto.response.OAuth2LoginResponseDto;
+import com.hf.healthfriend.global.spec.ApiBasicResponse;
+
+public class OAuth2LoginResponseSchema extends ApiBasicResponse<OAuth2LoginResponseDto> {
+}

--- a/src/main/java/com/hf/healthfriend/global/spec/schema/TokenRefreshResponseSchema.java
+++ b/src/main/java/com/hf/healthfriend/global/spec/schema/TokenRefreshResponseSchema.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.global.spec.schema;
+
+import com.hf.healthfriend.auth.oauth2.dto.response.TokenRefreshResponseDto;
+import com.hf.healthfriend.global.spec.ApiBasicResponse;
+
+public class TokenRefreshResponseSchema extends ApiBasicResponse<TokenRefreshResponseDto> {
+}

--- a/src/main/java/com/hf/healthfriend/global/util/SecuredHttpCookieUtils.java
+++ b/src/main/java/com/hf/healthfriend/global/util/SecuredHttpCookieUtils.java
@@ -13,6 +13,7 @@ public class SecuredHttpCookieUtils implements HttpCookieUtils {
     @Override
     public ResponseCookie buildResponseCookie(String name, String value) {
         return ResponseCookie.from(name, value)
+                .httpOnly(true)
                 .maxAge(CookieConstants.COOKIE_DURATION_IN_SECONDS.getInt())
                 .domain(this.domain)
                 .path("/")

--- a/src/main/resources/application-constants.yml
+++ b/src/main/resources/application-constants.yml
@@ -1,2 +1,2 @@
 client:
-  domain: localhost:3000
+  domain: localhost

--- a/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
@@ -134,6 +134,54 @@ class TestMemberService {
                 .isThrownBy(() -> this.memberService.createMember(testcase));
     }
 
+    @DisplayName("isMemberExists - exists member")
+    @Test
+    void isMemberExists_returnTrue() {
+        MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
+                .id("sample@gmail.com")
+                .nickname("샘플닉네임")
+                .birthDate(LocalDate.now())
+                .gender(Gender.MALE)
+                .introduction("안녕하세요. 뚱입니다.")
+                .fitnessLevel(FitnessLevel.ADVANCED)
+                .companionStyle(CompanionStyle.GROUP)
+                .fitnessEagerness(FitnessEagerness.LAZY)
+                .fitnessObjective(FitnessObjective.RUNNING)
+                .fitnessKind(FitnessKind.FUNCTIONAL)
+                .build();
+
+        log.info("requestDto={}", requestDto);
+
+        this.memberService.createMember(requestDto);
+
+        boolean memberExists = this.memberService.isMemberExists("sample@gmail.com");
+        assertThat(memberExists).isTrue();
+    }
+
+    @DisplayName("isMemberExists - not exists member")
+    @Test
+    void isMemberExists_returnFalse() {
+        MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
+                .id("sample@gmail.com")
+                .nickname("샘플닉네임")
+                .birthDate(LocalDate.now())
+                .gender(Gender.MALE)
+                .introduction("안녕하세요. 뚱입니다.")
+                .fitnessLevel(FitnessLevel.ADVANCED)
+                .companionStyle(CompanionStyle.GROUP)
+                .fitnessEagerness(FitnessEagerness.LAZY)
+                .fitnessObjective(FitnessObjective.RUNNING)
+                .fitnessKind(FitnessKind.FUNCTIONAL)
+                .build();
+
+        log.info("requestDto={}", requestDto);
+
+        this.memberService.createMember(requestDto);
+
+        boolean memberExists = this.memberService.isMemberExists("no@such.member");
+        assertThat(memberExists).isFalse();
+    }
+
     @DisplayName("findMember - Member 제대로 찾음")
     @Test
     void findMember_success() {


### PR DESCRIPTION
- Redirect URI를 백엔드로 설정함에 따라 소셜 로그인 Redirection을 받는 Controller Deprecated 제거
- Swagger 명세 보충