### PR TITLE
feat: 인증/인가 로직 끄는 설정

### DIFF
--- a/src/main/java/com/hf/healthfriend/auth/authentication/NoAuthAuthentication.java
+++ b/src/main/java/com/hf/healthfriend/auth/authentication/NoAuthAuthentication.java
@@ -1,0 +1,50 @@
+package com.hf.healthfriend.auth.authentication;
+
+import com.hf.healthfriend.auth.oauth2.principal.SingleAuthorityOAuth2Principal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class NoAuthAuthentication implements Authentication {
+    private final SingleAuthorityOAuth2Principal principal;
+
+    public NoAuthAuthentication(String name, GrantedAuthority authority) {
+        this.principal = new SingleAuthorityOAuth2Principal(name, authority);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.principal.getAuthorities();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return this.principal.getName();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/filter/JsonParserFilter.java
+++ b/src/main/java/com/hf/healthfriend/auth/filter/JsonParserFilter.java
@@ -1,0 +1,75 @@
+package com.hf.healthfriend.auth.filter;
+
+import com.hf.healthfriend.auth.authentication.NoAuthAuthentication;
+import com.hf.healthfriend.auth.oauth2.tokensupport.OAuth2TokenSupport;
+import com.hf.healthfriend.domain.member.constant.Role;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@Profile("no-auth")
+@RequiredArgsConstructor
+public class JsonParserFilter extends OncePerRequestFilter {
+    private final List<OAuth2TokenSupport> tokenSupports;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization == null) {
+            log.info("No authorization header");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (authorization.startsWith("Bearer ")) {
+            authorization = authorization.substring("Bearer ".length());
+        }
+
+        String email = null;
+        for (OAuth2TokenSupport tokenSupport : tokenSupports) {
+            try {
+                email = tokenSupport.requestEmail(authorization);
+            } catch (Exception e) {
+                log.trace("{} not works for {}", tokenSupport.getClass(), authorization, e);
+            }
+        }
+
+        if (email == null) {
+            log.info("No token support for Authorization: {}", authorization);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Optional<Member> memberOp = this.memberRepository.findByEmail(email);
+        if (memberOp.isEmpty()) {
+            log.info("No such member of email: {}", email);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Member member = memberOp.get();
+
+        Authentication authentication = new NoAuthAuthentication(String.valueOf(member.getId()), new SimpleGrantedAuthority(Role.ROLE_MEMBER.name()));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/DelegatingOpaqueTokenIntrospector.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/DelegatingOpaqueTokenIntrospector.java
@@ -7,6 +7,7 @@ import com.hf.healthfriend.domain.member.constant.Role;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("!no-auth")
 public class DelegatingOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
     private final List<OpaqueTokenIntrospectorDelegator> delegators;
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
@@ -7,11 +7,13 @@ import com.hf.healthfriend.auth.oauth2.tokensupport.GoogleOAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.dto.MemberDto;
 import com.hf.healthfriend.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!no-auth")
 public class GoogleOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntrospectorDelegator {
     private final MemberService memberService;
     private final GoogleOAuth2TokenSupport tokenSupport;

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
@@ -7,11 +7,13 @@ import com.hf.healthfriend.auth.oauth2.tokensupport.KakaoOAuth2TokenSupport;
 import com.hf.healthfriend.domain.member.dto.MemberDto;
 import com.hf.healthfriend.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!no-auth")
 public class KakaoOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntrospectorDelegator {
     private final MemberService memberService;
     private final KakaoOAuth2TokenSupport tokenSupport;

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/JsonBasedTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/JsonBasedTokenSupport.java
@@ -1,0 +1,43 @@
+package com.hf.healthfriend.auth.oauth2.tokensupport;
+
+import com.hf.healthfriend.auth.exception.InvalidCodeException;
+import com.hf.healthfriend.auth.oauth2.constant.AuthServer;
+import com.hf.healthfriend.auth.oauth2.dto.response.GrantedTokenInfo;
+import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("no-auth")
+public class JsonBasedTokenSupport implements OAuth2TokenSupport {
+
+    @Override
+    public GrantedTokenInfo grantToken(String code, String redirectUri) throws InvalidCodeException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TokenValidationInfo validateToken(String token) throws RuntimeException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String requestEmail(String accessToekn) throws RuntimeException {
+        log.trace("accessToken={}", accessToekn);
+        JSONObject jsonObject = new JSONObject(accessToekn);
+        return jsonObject.getString("email");
+    }
+
+    @Override
+    public String refreshToken(String refreshToken) throws RuntimeException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(AuthServer authServer) {
+        return true;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateGoogleTokenSupport.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
@@ -26,6 +27,7 @@ import java.time.temporal.ChronoUnit;
  */
 @Slf4j
 @Component
+@Profile("!no-auth")
 public class RestTemplateGoogleTokenSupport implements GoogleOAuth2TokenSupport {
     private static final String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
 

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/tokensupport/RestTemplateKakaoTokenSupport.java
@@ -7,6 +7,7 @@ import com.hf.healthfriend.auth.oauth2.dto.response.TokenValidationInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
@@ -24,6 +25,7 @@ import java.time.temporal.ChronoUnit;
  */
 @Slf4j
 @Component
+@Profile("!no-auth")
 public class RestTemplateKakaoTokenSupport implements KakaoOAuth2TokenSupport {
     private static final String KAKAO_TOKEN_REQUEST_URL = "https://kauth.kakao.com/oauth/token";
     private static final String KAKAO_INFO_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";


### PR DESCRIPTION
## 개요
API 테스트할 때마다 소셜 로그인을 해야 한다면 매우 번거로울 것이다. 그러므로 Spring Profile을 활용해서 쉽게 켜고 끌 수 있게 했다. "no-auth"를 추가하면 인증/인가 모듈이 꺼지고 "no-auth"를 생략하면 인증/인가 모듈이 켜진다.

## 변경된 점
- no-auth profile이 활성화되면 구동되는 Security Filter 구현
- 암호화되지 않은 JSON 형식으로 Authorization 헤더에 현재 로그인한 회원의 email을 삽입할 수 있음
- 기존의 OAuth 2.0 기반 인증/인가 담당 객체들은 no-auth profile이 활성화되면 Spring Bean으로 등록되지 않도록 설정

## 참고
[인증 및 인가 모듈 사용하기 매뉴얼](https://five-pendulum-ae2.notion.site/10776a96a9d78084ba2eff8eb92e8874?pvs=4)