### PR TITLE
Feature/커뮤니티 crud

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/post/controller/PostController.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/controller/PostController.java
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post API", description = "커뮤니티 API")
@@ -31,8 +30,8 @@ public class PostController {
             @ApiResponse(responseCode = "400", description = "작성 실패")
     })
     @PostMapping("/posts")
-    public ResponseEntity<ApiBasicResponse<Long>> create(@Valid @RequestBody PostWriteRequest postWriteRequest, BearerTokenAuthentication authentication) {
-        Long postId = postService.save(postWriteRequest, authentication);
+    public ResponseEntity<ApiBasicResponse<Long>> create(@Valid @RequestBody PostWriteRequest postWriteRequest) {
+        Long postId = postService.save(postWriteRequest);
         return ResponseEntity.ok(ApiBasicResponse.of(postId, HttpStatus.OK));
     }
 

--- a/src/main/java/com/hf/healthfriend/domain/post/dto/request/PostWriteRequest.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/dto/request/PostWriteRequest.java
@@ -5,9 +5,11 @@ import com.hf.healthfriend.domain.post.constant.PostCategory;
 import com.hf.healthfriend.domain.post.entity.Post;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class PostWriteRequest{
     @NotBlank
     String category;
@@ -17,6 +19,8 @@ public class PostWriteRequest{
     @NotBlank(message = "내용을 입력해주세요.")
     @Size(min = 10, max = 1000, message = "내용은 10자 이상 1000자 이하로 입력해주세요.")
     String content;
+    @NotBlank(message="작성자 아이디는 필수값입니다. ")
+    String writerId;
 
     public Post toEntity(Member member){
         PostCategory postCategory = PostCategory.valueOf(category);

--- a/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
@@ -10,14 +10,10 @@ import com.hf.healthfriend.domain.post.entity.Post;
 import com.hf.healthfriend.domain.post.exception.CustomException;
 import com.hf.healthfriend.domain.post.exception.PostErrorCode;
 import com.hf.healthfriend.domain.post.repository.PostRepository;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -28,10 +24,9 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
-    private final ViewService viewService;
 
-    public Long save(PostWriteRequest postWriteRequest, BearerTokenAuthentication authentication) {
-        String memberId = authentication.getName();
+    public Long save(PostWriteRequest postWriteRequest) {
+        String memberId = postWriteRequest.getWriterId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
         Post post = postWriteRequest.toEntity(member);

--- a/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
@@ -46,12 +46,10 @@ public class PostService {
     }
 
 
-    public PostGetResponse get(Long postId, HttpServletRequest request, HttpServletResponse response) {
+    public PostGetResponse get(Long postId,boolean canUpdateViewCount) {
         Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new CustomException(PostErrorCode.NON_EXIST_POST, HttpStatus.NOT_FOUND));
-        if(viewService.canAddViewCount(request,postId)) {
-            Cookie cookie = viewService.createCookie(postId);
-            response.addCookie(cookie);
+        if(canUpdateViewCount) {
             post.updateViewCount(post.getViewCount());
         }
         return PostGetResponse.builder()

--- a/src/main/java/com/hf/healthfriend/domain/post/service/ViewService.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/service/ViewService.java
@@ -8,26 +8,18 @@ import java.util.Arrays;
 
 @Service
 public class ViewService {
-    public boolean canAddViewCount(HttpServletRequest request, Long postId) {
-        Cookie[] cookies = request.getCookies();
-        if(cookies == null) {
+    public boolean canAddViewCount(String cookieValue, Long postId) {
+        if(cookieValue == null || cookieValue.isEmpty()) {
             return true;
         }
-        return Arrays.stream(cookies)
-                .noneMatch(cookie -> cookie.getName().equals("visit") &&
-                        cookie.getValue().contains(toString(postId)));
+        return !cookieValue.contains(String.valueOf(postId));
     }
 
-    public Cookie createCookie(Long id) {
-        Cookie cookie = new Cookie("visit", toString(id));
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24);
-        return cookie;
-    }
-
-    private String toString(Long id) {
-        return String.valueOf(id);
+    public String addPostIdToVisitCookie(String visitCookieValue, Long postId) {
+        if (visitCookieValue == null) {
+            return "/" + postId + "/";
+        }
+        return visitCookieValue + postId + "/";
     }
 
 }


### PR DESCRIPTION
## 개요 
- 비즈니스 로직에서 서블릿 의존성 분리
- 비즈니스 로직에서 시큐리티 의존성 분리

## 변경된 점
- 기존 서비스에서 처리하던 쿠키 로직을 컨트롤러 레이어로 이전했습니다
- 기존 파라미터로 받던 BearerTokenAuthentication를 제거하고 request dto에 writerId를 포함시키는 방식으로 변경했습니다. 
