### PR TITLE
Feature/댓글 crud#35

### DIFF
--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig {
                         .httpBasic(AbstractHttpConfigurer::disable)
                         .authorizeHttpRequests((auth) -> auth
                                 .requestMatchers(WHITE_LIST).permitAll()
-                                .requestMatchers(HttpMethod.POST, "/members").hasAnyRole(
+                                .requestMatchers(HttpMethod.POST, "/hr/members").hasAnyRole(
                                         Role.ROLE_NON_MEMBER.roleName(), Role.ROLE_MEMBER.roleName()
                                 )
                                 .anyRequest().hasAnyRole(Role.ROLE_ADMIN.roleName(), Role.ROLE_MEMBER.roleName())

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2RedirectionController.java
@@ -162,7 +162,7 @@ public class OAuth2RedirectionController {
         // 너무 간단한 로직이므로 Service 객체를 따로 정의하지 않고 여기서 했다.
         GrantedTokenInfo grantedTokenInfo = tokenSupport.grantToken(code, redirectUri);
 
-        boolean memberExists = this.memberService.isMemberExists(grantedTokenInfo.getEmail());
+        boolean memberExists = this.memberService.isMemberOfEmailExists(grantedTokenInfo.getEmail());
 
         ResponseCookie refreshTokenCookie =
                 this.cookieUtils.buildHttpOnlyResponseCookie(CookieConstants.COOKIE_NAME_REFRESH_TOKEN.getString(),

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -139,11 +139,11 @@ public class OAuth2TokenController {
             )
     })
     public ResponseEntity<ApiBasicResponse<MemberDto>> whoAmI() {
-        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        long id = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
         if (log.isTraceEnabled()) {
-            log.trace("Logged In OAuth 2.0 Member={}", loginId);
+            log.trace("Logged In OAuth 2.0 Member={}", id);
         }
-        MemberDto memberDto = this.memberService.findMemberByLoginId(loginId);
+        MemberDto memberDto = this.memberService.findMember(id);
         return ResponseEntity.ok(
                 ApiBasicResponse.of(
                         memberDto,

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/controller/OAuth2TokenController.java
@@ -139,11 +139,11 @@ public class OAuth2TokenController {
             )
     })
     public ResponseEntity<ApiBasicResponse<MemberDto>> whoAmI() {
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
         if (log.isTraceEnabled()) {
-            log.trace("Logged In OAuth 2.0 Member={}", memberId);
+            log.trace("Logged In OAuth 2.0 Member={}", loginId);
         }
-        MemberDto memberDto = this.memberService.findMember(memberId);
+        MemberDto memberDto = this.memberService.findMemberByLoginId(loginId);
         return ResponseEntity.ok(
                 ApiBasicResponse.of(
                         memberDto,

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/DelegatingOpaqueTokenIntrospector.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/DelegatingOpaqueTokenIntrospector.java
@@ -33,8 +33,8 @@ public class DelegatingOpaqueTokenIntrospector implements OpaqueTokenIntrospecto
                 return delegator.introspect(token);
             } catch (MemberNotFoundException e) {
                 // Token의 Owner가 우리 서비스에 등록되지 않을 경우 (DB에 없을 경우) 발생
-                log.warn("등록되지 않은 사용자: {}", e.getMemberId());
-                return new SingleAuthorityOAuth2Principal(e.getMemberId(), Role.ROLE_NON_MEMBER);
+                log.warn("등록되지 않은 사용자: {}", e.getLoginId());
+                return new SingleAuthorityOAuth2Principal(e.getLoginId(), Role.ROLE_NON_MEMBER);
             } catch (Exception e) { // TODO: 더 세밀한 예외 처리 필요 (아마?)
                 log.warn("{}는 지원하지 않음", delegator.getSupportingAuthServer(), e);
             }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
@@ -23,7 +23,7 @@ public class GoogleOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntros
         TokenValidationInfo tokenValidationInfo = this.tokenSupport.validateToken(token);
         MemberDto memberDto = this.memberService.findMemberByEmail(tokenValidationInfo.getEmail());
         return new SingleAuthorityOAuth2Principal(
-                memberDto.getLoginId(),
+                String.valueOf(memberDto.getMemberId()),
                 memberDto.getRole()
         );
     }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/GoogleOpaqueTokenIntrospectorDelegator.java
@@ -21,9 +21,9 @@ public class GoogleOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntros
     @Override
     public OAuth2AuthenticatedPrincipal introspect(String token) {
         TokenValidationInfo tokenValidationInfo = this.tokenSupport.validateToken(token);
-        MemberDto memberDto = this.memberService.findMember(tokenValidationInfo.getEmail());
+        MemberDto memberDto = this.memberService.findMemberByEmail(tokenValidationInfo.getEmail());
         return new SingleAuthorityOAuth2Principal(
-                memberDto.getMemberId(),
+                memberDto.getLoginId(),
                 memberDto.getRole()
         );
     }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
@@ -22,9 +22,9 @@ public class KakaoOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntrosp
     public OAuth2AuthenticatedPrincipal introspect(String token) {
         // TODO: GoogleOpaqueTokenIntrospectorDelegator와 똑같은 로직이 반복된다. 굳이 둘로 나눌 필요는 없을지도
         TokenValidationInfo tokenValidationInfo = this.tokenSupport.validateToken(token);
-        MemberDto memberDto = this.memberService.findMember(tokenValidationInfo.getEmail());
+        MemberDto memberDto = this.memberService.findMemberByEmail(tokenValidationInfo.getEmail());
         return new SingleAuthorityOAuth2Principal(
-                memberDto.getMemberId(),
+                memberDto.getLoginId(),
                 memberDto.getRole()
         );
     }

--- a/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/auth/oauth2/introspect/delegator/KakaoOpaqueTokenIntrospectorDelegator.java
@@ -24,7 +24,7 @@ public class KakaoOpaqueTokenIntrospectorDelegator implements OpaqueTokenIntrosp
         TokenValidationInfo tokenValidationInfo = this.tokenSupport.validateToken(token);
         MemberDto memberDto = this.memberService.findMemberByEmail(tokenValidationInfo.getEmail());
         return new SingleAuthorityOAuth2Principal(
-                memberDto.getLoginId(),
+                String.valueOf(memberDto.getMemberId()),
                 memberDto.getRole()
         );
     }

--- a/src/main/java/com/hf/healthfriend/domain/BaseTimeEntity.java
+++ b/src/main/java/com/hf/healthfriend/domain/BaseTimeEntity.java
@@ -3,6 +3,7 @@ package com.hf.healthfriend.domain;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {

--- a/src/main/java/com/hf/healthfriend/domain/BaseTimeEntity.java
+++ b/src/main/java/com/hf/healthfriend/domain/BaseTimeEntity.java
@@ -2,17 +2,17 @@ package com.hf.healthfriend.domain;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@Setter(AccessLevel.PROTECTED)
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {

--- a/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
@@ -1,0 +1,63 @@
+package com.hf.healthfriend.domain.comment.accesscontrol;
+
+import com.hf.healthfriend.auth.accesscontrol.AccessControlTrigger;
+import com.hf.healthfriend.auth.accesscontrol.AccessController;
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.repository.CommentRepository;
+import com.hf.healthfriend.domain.member.constant.Role;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@AccessController
+@RequiredArgsConstructor
+public class CommentAccessController {
+    private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
+
+    @AccessControlTrigger(path = "/hr/comments/{commentId}", method = "DELETE")
+    public boolean accessControlForCreatingComment(BearerTokenAuthentication authentication, HttpServletRequest request) {
+        return controlAccessToCommentResourceByCommentId(authentication, request);
+    }
+
+    @AccessControlTrigger(path = "/hr/comments/{commentId}", method = "PATCH")
+    public boolean accessControlForUpdatingComment(BearerTokenAuthentication authentication, HttpServletRequest request) {
+        return controlAccessToCommentResourceByCommentId(authentication, request);
+    }
+
+    private boolean controlAccessToCommentResourceByCommentId(BearerTokenAuthentication authentication, HttpServletRequest request) {
+        // TODO: AccessControlFilter에서 글로벌하게 처리해야 한다 (혹은 AOP)
+        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).anyMatch((g) -> Role.ROLE_ADMIN.name().equals(g))) {
+            return true;
+        }
+
+        String path = request.getRequestURI();
+        long commentIdBeingAccessed = Long.parseLong(path.substring(path.lastIndexOf('/') + 1));
+
+        Optional<Comment> commentOp = this.commentRepository.findById(commentIdBeingAccessed);
+        if (commentOp.isEmpty()) {
+            return true; // 그대로 진행시켜서 404 Not Found가 나도록
+        }
+
+        Optional<Member> accessingMemberOp = this.memberRepository.findByEmail(authentication.getName());
+        if (accessingMemberOp.isEmpty()) {
+            return false;
+        }
+
+        Member accessingMember = accessingMemberOp.get();
+
+        log.debug("accessingMember={}", accessingMember);
+
+        Comment comment = commentOp.get();
+        return comment.getWriter().getId().equals(accessingMember.getId());
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
@@ -5,23 +5,18 @@ import com.hf.healthfriend.auth.accesscontrol.AccessController;
 import com.hf.healthfriend.domain.comment.entity.Comment;
 import com.hf.healthfriend.domain.comment.repository.CommentRepository;
 import com.hf.healthfriend.domain.member.constant.Role;
-import com.hf.healthfriend.domain.member.entity.Member;
-import com.hf.healthfriend.domain.member.repository.MemberRepository;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 
-import java.io.IOException;
 import java.util.Optional;
 
 @Slf4j
 @AccessController
 @RequiredArgsConstructor
 public class CommentAccessController {
-    private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
 
     @AccessControlTrigger(path = "/hr/comments/{commentId}", method = "DELETE")
@@ -48,16 +43,13 @@ public class CommentAccessController {
             return true; // 그대로 진행시켜서 404 Not Found가 나도록
         }
 
-        Optional<Member> accessingMemberOp = this.memberRepository.findByEmail(authentication.getName());
-        if (accessingMemberOp.isEmpty()) {
-            return false;
+        if (log.isTraceEnabled()) {
+            log.trace("authentication={}", authentication);
+            log.trace("authentication.principal={}", authentication.getPrincipal());
+            log.trace("authentication.name={}", authentication.getName());
         }
 
-        Member accessingMember = accessingMemberOp.get();
-
-        log.debug("accessingMember={}", accessingMember);
-
         Comment comment = commentOp.get();
-        return comment.getWriter().getId().equals(accessingMember.getId());
+        return comment.getWriter().getId().equals(Long.parseLong(authentication.getName()));
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -45,4 +45,11 @@ public class CommentController {
         log.info("result={}", result);
         return ResponseEntity.ok(ApiBasicResponse.of(result, HttpStatus.OK));
     }
+
+    @GetMapping("/comments")
+    public ResponseEntity<ApiBasicResponse<List<CommentDto>>> findCommentsOfSpecificMember(@RequestParam("writerId") long writerId) {
+        List<CommentDto> result = this.commentService.getCommentsOfWriter(writerId);
+        log.info("result={}", result);
+        return ResponseEntity.ok(ApiBasicResponse.of(result, HttpStatus.OK));
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -1,0 +1,33 @@
+package com.hf.healthfriend.domain.comment.controller;
+
+import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
+import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.comment.service.CommentService;
+import com.hf.healthfriend.global.spec.ApiBasicResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hr")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiBasicResponse<CommentCreationResponseDto>> createComment(
+            @PathVariable("postId") long postId,
+            @RequestBody CommentCreationRequestDto requestDto) {
+        CommentCreationResponseDto result = this.commentService.createComment(postId, requestDto);
+        return ResponseEntity.created(UriComponentsBuilder.fromPath("/posts/{postId}/comments/{commentId}")
+                        .buildAndExpand(Map.of("postId", postId, "commentId", result.getCommentId()))
+                        .toUri())
+                .body(ApiBasicResponse.of(result, HttpStatus.CREATED));
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import com.hf.healthfriend.domain.comment.service.CommentService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -35,10 +36,10 @@ public class CommentController {
     )
     public ResponseEntity<ApiBasicResponse<CommentCreationResponseDto>> createComment(
             @PathVariable("postId") long postId,
-            @RequestBody CommentCreationRequestDto requestDto) {
+            @RequestBody @Valid CommentCreationRequestDto requestDto) {
         CommentCreationResponseDto result = this.commentService.createComment(postId, requestDto);
         return ResponseEntity.created(UriComponentsBuilder.fromPath("/posts/{postId}/comments/{commentId}")
-                        .buildAndExpand(Map.of("postId", postId, "commentId", result.getCommentId()))
+                        .buildAndExpand(Map.of("postId", postId, "commentId", result.commentId()))
                         .toUri())
                 .body(ApiBasicResponse.of(result, HttpStatus.CREATED));
     }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.comment.controller;
 
+import com.hf.healthfriend.domain.comment.dto.CommentDto;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.service.CommentService;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -35,5 +37,12 @@ public class CommentController {
     public ResponseEntity<ApiBasicResponse<Void>> deleteComment(@PathVariable("commentId") long commentId) {
         this.commentService.deleteComment(commentId);
         return ResponseEntity.ok(ApiBasicResponse.of(HttpStatus.OK));
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiBasicResponse<List<CommentDto>>> findCommentsOfSpecificPost(@PathVariable("postId") long postId) {
+        List<CommentDto> result = this.commentService.getCommentsOfPost(postId);
+        log.info("result={}", result);
+        return ResponseEntity.ok(ApiBasicResponse.of(result, HttpStatus.OK));
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -6,6 +6,8 @@ import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDt
 import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import com.hf.healthfriend.domain.comment.service.CommentService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,6 +26,13 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "댓글 작성", description = "{postId}에 해당하는 포스트에 댓글 작성",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "댓글 작성 성공"),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 POST, 혹은 존재하지 않는 회원")
+            }
+    )
     public ResponseEntity<ApiBasicResponse<CommentCreationResponseDto>> createComment(
             @PathVariable("postId") long postId,
             @RequestBody CommentCreationRequestDto requestDto) {
@@ -35,12 +44,27 @@ public class CommentController {
     }
 
     @DeleteMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 삭제", description = "{commentId}에 해당하는 댓글 삭제",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "삭제 성공"),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 댓글을 삭제하려고 할 경우")
+            }
+    )
     public ResponseEntity<ApiBasicResponse<Void>> deleteComment(@PathVariable("commentId") long commentId) {
         this.commentService.deleteComment(commentId);
         return ResponseEntity.ok(ApiBasicResponse.of(HttpStatus.OK));
     }
 
     @GetMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "댓글 목록 조회",
+            description = "{postId}에 해당하는 포스트에 달린 댓글을 조회",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+                    @ApiResponse(responseCode = "404", description = "{postId}에 해당하는 댓글이 없을 경우")
+            }
+    )
     public ResponseEntity<ApiBasicResponse<List<CommentDto>>> findCommentsOfSpecificPost(@PathVariable("postId") long postId) {
         List<CommentDto> result = this.commentService.getCommentsOfPost(postId);
         log.info("result={}", result);
@@ -48,6 +72,15 @@ public class CommentController {
     }
 
     @GetMapping("/comments")
+    @Operation(
+            summary = "특정 회원의 댓글 목록 조회",
+            description = "Query Parameter의 writerId에 해당하는 회원의 댓글 목록 조회",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "Query Parameter에 writerId가 없을 때"),
+                    @ApiResponse(responseCode = "404", description = "그런 회원 없을 때")
+            }
+    )
     public ResponseEntity<ApiBasicResponse<List<CommentDto>>> findCommentsOfSpecificMember(@RequestParam("writerId") long writerId) {
         List<CommentDto> result = this.commentService.getCommentsOfWriter(writerId);
         log.info("result={}", result);
@@ -55,6 +88,13 @@ public class CommentController {
     }
 
     @PatchMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 수정",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+                    @ApiResponse(responseCode = "404", description = "commentId에 해당하는 댓글이 존재하지 않을 때")
+            }
+    )
     public ResponseEntity<ApiBasicResponse<CommentDto>> updateComment(@PathVariable("commentId") long commentId,
                                                                       @RequestBody CommentUpdateDto requestDto) {
         CommentDto updatedCommentDto = this.commentService.updateComment(commentId, requestDto);

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -30,4 +30,10 @@ public class CommentController {
                         .toUri())
                 .body(ApiBasicResponse.of(result, HttpStatus.CREATED));
     }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiBasicResponse<Void>> deleteComment(@PathVariable("commentId") long commentId) {
+        this.commentService.deleteComment(commentId);
+        return ResponseEntity.ok(ApiBasicResponse.of(HttpStatus.OK));
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.hf.healthfriend.domain.comment.controller;
 import com.hf.healthfriend.domain.comment.dto.CommentDto;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import com.hf.healthfriend.domain.comment.service.CommentService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
 import lombok.RequiredArgsConstructor;
@@ -51,5 +52,13 @@ public class CommentController {
         List<CommentDto> result = this.commentService.getCommentsOfWriter(writerId);
         log.info("result={}", result);
         return ResponseEntity.ok(ApiBasicResponse.of(result, HttpStatus.OK));
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<ApiBasicResponse<CommentDto>> updateComment(@PathVariable("commentId") long commentId,
+                                                                      @RequestBody CommentUpdateDto requestDto) {
+        CommentDto updatedCommentDto = this.commentService.updateComment(commentId, requestDto);
+        log.info("updatedCommentDto={}", updatedCommentDto);
+        return ResponseEntity.ok(ApiBasicResponse.of(updatedCommentDto, HttpStatus.OK));
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentErrorCode.java
@@ -1,5 +1,22 @@
 package com.hf.healthfriend.domain.comment.controller.exceptionhandler;
 
-public enum CommentErrorCode {
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public enum CommentErrorCode {
+    COMMENT_NOT_FOUND(315, "존재하지 않는 댓글입니다."),
+    POST_NOT_EXISTS(316, "존재하지 않는 포스트입니다.") // TODO
+    ;
+
+    private final int code;
+    private final String message;
+
+    public int code() {
+        return this.code;
+    }
+
+    public String message() {
+        return this.message;
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentErrorCode.java
@@ -1,0 +1,5 @@
+package com.hf.healthfriend.domain.comment.controller.exceptionhandler;
+
+public enum CommentErrorCode {
+
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentExceptionHandlerControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentExceptionHandlerControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.hf.healthfriend.domain.comment.controller.exceptionhandler;
+
+import com.hf.healthfriend.global.spec.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.hf.healthfriend.domain.comment")
+public class CommentExceptionHandlerControllerAdvice {
+
+//    @ExceptionHandler(DataIntegrityViolationException.class)
+//    public ResponseEntity<ApiErrorResponse> dataIntegrityViolationException(DataIntegrityViolationException e) {
+//        log.error("DataIntegrityViolationException occurred", e);
+//        return ResponseEntity.badRequest()
+//                .body(ApiErrorResponse.builder()
+//                        .errorCode());
+//    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentExceptionHandlerControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/controller/exceptionhandler/CommentExceptionHandlerControllerAdvice.java
@@ -1,21 +1,66 @@
 package com.hf.healthfriend.domain.comment.controller.exceptionhandler;
 
+import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
 import com.hf.healthfriend.global.spec.ApiErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.hf.healthfriend.domain.comment.controller.exceptionhandler.CommentErrorCode.COMMENT_NOT_FOUND;
+import static com.hf.healthfriend.domain.comment.controller.exceptionhandler.CommentErrorCode.POST_NOT_EXISTS;
+import static com.hf.healthfriend.global.exception.ErrorCode.MEMBER_OF_THE_MEMBER_ID_NOT_FOUND;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Slf4j
 @RestControllerAdvice(basePackages = "com.hf.healthfriend.domain.comment")
 public class CommentExceptionHandlerControllerAdvice {
 
-//    @ExceptionHandler(DataIntegrityViolationException.class)
-//    public ResponseEntity<ApiErrorResponse> dataIntegrityViolationException(DataIntegrityViolationException e) {
-//        log.error("DataIntegrityViolationException occurred", e);
-//        return ResponseEntity.badRequest()
-//                .body(ApiErrorResponse.builder()
-//                        .errorCode());
-//    }
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> dataIntegrityViolationException(CommentNotFoundException e) {
+        log.error("CommentNotFoundException occurred", e);
+        return new ResponseEntity<>(
+                ApiErrorResponse.builder()
+                        .errorCode(COMMENT_NOT_FOUND.code())
+                        .errorName(COMMENT_NOT_FOUND.name())
+                        .message(COMMENT_NOT_FOUND.message() + ": " + e.getCommentId())
+                        .statusCode(NOT_FOUND.value())
+                        .statusCodeSeries(NOT_FOUND.series().value())
+                        .build(),
+                NOT_FOUND
+        );
+    }
+
+    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+    public ResponseEntity<ApiErrorResponse> invalidDataAccessApiUsageException(InvalidDataAccessApiUsageException e) {
+        log.error("InvalidDataAccessApiUsageException occurred", e);
+        return new ResponseEntity<>(
+                ApiErrorResponse.builder()
+                        // TODO: post 도메인 쪽 ErrorCode를 활용하는 게 더 좋아 보인다.
+                        .errorCode(POST_NOT_EXISTS.code())
+                        .errorName(POST_NOT_EXISTS.name())
+                        .message(POST_NOT_EXISTS.message())
+                        .statusCode(NOT_FOUND.value())
+                        .statusCodeSeries(NOT_FOUND.series().value())
+                        .build(),
+                NOT_FOUND
+        );
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiErrorResponse> DataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException occurred", e);
+        return new ResponseEntity<>(
+                ApiErrorResponse.builder()
+                        .errorCode(MEMBER_OF_THE_MEMBER_ID_NOT_FOUND.code())
+                        .errorName(MEMBER_OF_THE_MEMBER_ID_NOT_FOUND.name())
+                        .message(MEMBER_OF_THE_MEMBER_ID_NOT_FOUND.message())
+                        .statusCode(NOT_FOUND.value())
+                        .statusCodeSeries(NOT_FOUND.series().value())
+                        .build(),
+                NOT_FOUND
+        );
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/CommentDto.java
@@ -1,0 +1,20 @@
+package com.hf.healthfriend.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@ToString
+public class CommentDto {
+    private final Long commentId;
+    private final Long postId;
+    private final Long writerId;
+    private final String content;
+    private final LocalDateTime creationTime;
+    private final LocalDateTime lastModified;
+    private final boolean isDeleted;
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/CommentDto.java
@@ -1,20 +1,31 @@
 package com.hf.healthfriend.domain.comment.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @Getter
 @ToString
 public class CommentDto {
-    private final Long commentId;
-    private final Long postId;
-    private final Long writerId;
-    private final String content;
-    private final LocalDateTime creationTime;
-    private final LocalDateTime lastModified;
-    private final boolean isDeleted;
+    private Long commentId;
+    private Long postId;
+    private Long writerId;
+    private String content;
+    private LocalDateTime creationTime;
+    private LocalDateTime lastModified;
+
+    public static CommentDto of(Comment entity) {
+        return CommentDto.builder()
+                .commentId(entity.getCommentId())
+                .postId(entity.getPost().getPostId())
+                .writerId(entity.getWriter().getId())
+                .content(entity.getContent())
+                .creationTime(entity.getCreationTime())
+                .lastModified(entity.getLastModified())
+                .build();
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/request/CommentCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/request/CommentCreationRequestDto.java
@@ -1,5 +1,7 @@
 package com.hf.healthfriend.domain.comment.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -9,6 +11,10 @@ import lombok.*;
 @EqualsAndHashCode
 @ToString
 public class CommentCreationRequestDto {
-    private long writerId;
+
+    @NotNull
+    private Long writerId;
+
+    @NotEmpty
     private String content;
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/request/CommentCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/request/CommentCreationRequestDto.java
@@ -1,0 +1,14 @@
+package com.hf.healthfriend.domain.comment.dto.request;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class CommentCreationRequestDto {
+    private long writerId;
+    private String content;
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/response/CommentCreationResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/response/CommentCreationResponseDto.java
@@ -1,20 +1,15 @@
 package com.hf.healthfriend.domain.comment.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
 @Builder
-@Getter
-@ToString
-public class CommentCreationResponseDto {
-    private final long commentId;
-    private final long postId;
-    private final long writerId;
-    private final String content;
-    private LocalDateTime creationTime;
+public record CommentCreationResponseDto(
+        long commentId,
+        long postId,
+        long writerId,
+        String content,
+        LocalDateTime creationTime
+) {
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/dto/response/CommentCreationResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/dto/response/CommentCreationResponseDto.java
@@ -1,0 +1,20 @@
+package com.hf.healthfriend.domain.comment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class CommentCreationResponseDto {
+    private final long commentId;
+    private final long postId;
+    private final long writerId;
+    private final String content;
+    private LocalDateTime creationTime;
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
 @Setter
@@ -45,9 +45,31 @@ public class Comment {
     private LocalDateTime lastModified = null;
 
     @Column(name = "is_deleted")
+    @Builder.Default
     private boolean isDeleted = false;
+
+    public Comment(@NotNull Post post, @NotNull Member writer, String content) {
+        this.post = post;
+        this.writer = writer;
+        this.content = content;
+        this.creationTime = LocalDateTime.now();
+        this.isDeleted = false;
+    }
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    @Override
+    public String toString() {
+        return "Comment{" +
+                "commentId=" + commentId +
+                ", postId=" + post.getPostId() +
+                ", writerId=" + writer.getId() +
+                ", content='" + content + '\'' +
+                ", creationTime=" + creationTime +
+                ", lastModified=" + lastModified +
+                ", isDeleted=" + isDeleted +
+                '}';
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.comment.entity;
 
+import com.hf.healthfriend.domain.BaseTimeEntity;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.post.entity.Post;
 import jakarta.persistence.*;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @Setter
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,16 +35,6 @@ public class Comment {
     @Column(name = "content")
     private String content;
 
-    @Column(name = "creation_time")
-    @Temporal(TemporalType.TIMESTAMP)
-    @Builder.Default
-    private LocalDateTime creationTime = LocalDateTime.now();
-
-    @Column(name = "last_modified")
-    @Temporal(TemporalType.TIMESTAMP)
-    @Builder.Default
-    private LocalDateTime lastModified = null;
-
     @Column(name = "is_deleted")
     @Builder.Default
     private boolean isDeleted = false;
@@ -52,7 +43,6 @@ public class Comment {
         this.post = post;
         this.writer = writer;
         this.content = content;
-        this.creationTime = LocalDateTime.now();
         this.isDeleted = false;
     }
 
@@ -67,8 +57,8 @@ public class Comment {
                 ", postId=" + post.getPostId() +
                 ", writerId=" + writer.getId() +
                 ", content='" + content + '\'' +
-                ", creationTime=" + creationTime +
-                ", lastModified=" + lastModified +
+                ", creationTime=" + super.getCreationTime() +
+                ", lastModified=" + super.getLastModified() +
                 ", isDeleted=" + isDeleted +
                 '}';
     }

--- a/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
-@Setter
 public class Comment extends BaseTimeEntity {
 
     @Id
@@ -44,6 +43,14 @@ public class Comment extends BaseTimeEntity {
         this.writer = writer;
         this.content = content;
         this.isDeleted = false;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateLastModified(LocalDateTime modifiedTime) {
+        super.setLastModified(modifiedTime);
     }
 
     public void delete() {

--- a/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/entity/Comment.java
@@ -1,0 +1,53 @@
+package com.hf.healthfriend.domain.comment.entity;
+
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.post.entity.Post;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    private Member writer;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "creation_time")
+    @Temporal(TemporalType.TIMESTAMP)
+    @Builder.Default
+    private LocalDateTime creationTime = LocalDateTime.now();
+
+    @Column(name = "last_modified")
+    @Temporal(TemporalType.TIMESTAMP)
+    @Builder.Default
+    private LocalDateTime lastModified = null;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,35 @@
+package com.hf.healthfriend.domain.comment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CommentNotFoundException extends RuntimeException {
+    private Long commentId;
+
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+
+    public CommentNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CommentNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public CommentNotFoundException(String message, Long commentId) {
+        super(message);
+        this.commentId = commentId;
+    }
+
+    public CommentNotFoundException(String message, Throwable cause, Long commentId) {
+        super(message, cause);
+        this.commentId = commentId;
+    }
+
+    public CommentNotFoundException(Throwable cause, Long commentId) {
+        super(cause);
+        this.commentId = commentId;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
@@ -16,4 +16,12 @@ public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
                 AND c.isDeleted = FALSE
             """)
     List<Comment> findByPostId(@Param("postId") long postId);
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.writer.id = :writerId
+                AND c.isDeleted = FALSE
+            """)
+    List<Comment> findByWriterId(@Param("writerId") long writerId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.domain.comment.repository;
+
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
@@ -6,8 +6,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.commentId = :commentId
+                AND c.isDeleted = FALSE
+            """)
+    Optional<Comment> findById(@Param("commentId") Long commentId);
 
     @Query("""
             SELECT c

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentJpaRepository.java
@@ -2,6 +2,18 @@ package com.hf.healthfriend.domain.comment.repository;
 
 import com.hf.healthfriend.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.post.postId = :postId
+                AND c.isDeleted = FALSE
+            """)
+    List<Comment> findByPostId(@Param("postId") long postId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.domain.comment.repository;
+
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.comment.repository;
 
 import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
 import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,16 +26,15 @@ public class CommentRepository {
     /**
      * Comment 논리 삭제. 논리 삭제이기 때문에 실제로 데이터베이스에서 레코드가 삭제되지 않고, is_deleted 칼럼이 true로 set된다.
      * @param commentId 논리 삭제를 수행할 대상 entity
-     * @return commentId에 해당하는 Comment entity가 존재해서 삭제에 성공하면 true, 그렇지 않으면 false
+     * @throws CommentNotFoundException commentId에 해당하는 Comment entity가 존재하지 않을 경우
      */
-    public boolean deleteById(Long commentId) {
+    public void deleteById(Long commentId) throws CommentNotFoundException {
         Optional<Comment> commentOp = this.commentJpaRepository.findById(commentId);
         if (commentOp.isEmpty()) {
-            return false;
+            throw new CommentNotFoundException("Comment entity of commentId not exists", commentId);
         }
         Comment comment = commentOp.get();
         comment.setDeleted(true);
-        return true;
     }
 
     public Optional<Comment> findById(Long commentId) {
@@ -50,10 +50,18 @@ public class CommentRepository {
         return this.commentJpaRepository.findByWriterId(writerId);
     }
 
-    public Comment updateComment(Long commentId, CommentUpdateDto updateDto) {
+    /**
+     * Repository에 있는 Comment entity를 수정한다. 파라미터로 넘겨지는 updateDto 인스턴스의 필드 값 중 null 값은 무시된다.
+     *
+     * @param commentId 수정할 Comment의 ID
+     * @param updateDto Comment의 값은 이 DTO 인스턴스에 저장된 값으로 변경된다. 필드에 null이 존재해도 된다
+     * @return 수정된 Comment entity
+     * @throws CommentNotFoundException commentId에 해당하는 Comment entity가 존재하지 않을 경우
+     */
+    public Comment updateComment(Long commentId, CommentUpdateDto updateDto) throws CommentNotFoundException {
         Optional<Comment> commentOp = this.commentJpaRepository.findById(commentId);
         if (commentOp.isEmpty()) {
-            throw new NoSuchElementException(); // TODO: 이 Exception 써도 되나?
+            throw new CommentNotFoundException("Comment entity of commentId not exists", commentId);
         }
         Comment comment = commentOp.get();
 

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -1,10 +1,16 @@
 package com.hf.healthfriend.domain.comment.repository;
 
 import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Repository
@@ -31,6 +37,10 @@ public class CommentRepository {
         return true;
     }
 
+    public Optional<Comment> findById(Long commentId) {
+        return this.commentJpaRepository.findById(commentId);
+    }
+
     public List<Comment> findCommentsByPostId(Long postId) {
         return this.commentJpaRepository.findByPostId(postId);
     }
@@ -38,5 +48,20 @@ public class CommentRepository {
     // TODO: 추후 Pagination이 필요할 듯
     public List<Comment> findCommentsByWriterId(Long writerId) {
         return this.commentJpaRepository.findByWriterId(writerId);
+    }
+
+    public Comment updateComment(Long commentId, CommentUpdateDto updateDto) {
+        Optional<Comment> commentOp = this.commentJpaRepository.findById(commentId);
+        if (commentOp.isEmpty()) {
+            throw new NoSuchElementException(); // TODO: 이 Exception 써도 되나?
+        }
+        Comment comment = commentOp.get();
+
+        // TODO: Java Reflection을 활용해 유연한 update가 가능할 듯
+        if (updateDto.getContent() != null) {
+            comment.setContent(updateDto.getContent());
+        }
+        comment.setLastModified(LocalDateTime.now()); // TODO: Update DTO의 모든 null일 경우 어떻게 할까?
+        return comment;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -6,12 +6,8 @@ import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -30,7 +30,7 @@ public class CommentRepository {
             throw new CommentNotFoundException("Comment entity of commentId not exists", commentId);
         }
         Comment comment = commentOp.get();
-        comment.setDeleted(true);
+        comment.delete();
     }
 
     public Optional<Comment> findById(Long commentId) {
@@ -63,9 +63,9 @@ public class CommentRepository {
 
         // TODO: Java Reflection을 활용해 유연한 update가 가능할 듯
         if (updateDto.getContent() != null) {
-            comment.setContent(updateDto.getContent());
+            comment.updateContent(updateDto.getContent());
         }
-        comment.setLastModified(LocalDateTime.now()); // TODO: Update DTO의 모든 null일 경우 어떻게 할까?
+        comment.updateLastModified(LocalDateTime.now()); // TODO: Update DTO의 모든 null일 경우 어떻게 할까?
         return comment;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -34,4 +34,9 @@ public class CommentRepository {
     public List<Comment> findCommentsByPostId(Long postId) {
         return this.commentJpaRepository.findByPostId(postId);
     }
+
+    // TODO: 추후 Pagination이 필요할 듯
+    public List<Comment> findCommentsByWriterId(Long writerId) {
+        return this.commentJpaRepository.findByWriterId(writerId);
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,32 @@
 package com.hf.healthfriend.domain.comment.repository;
 
 import com.hf.healthfriend.domain.comment.entity.Comment;
-import org.springframework.data.jpa.repository.JpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepository {
+    private final CommentJpaRepository commentJpaRepository;
+
+    public Comment save(Comment commentToSave) {
+        return this.commentJpaRepository.save(commentToSave);
+    }
+
+    /**
+     * Comment 논리 삭제. 논리 삭제이기 때문에 실제로 데이터베이스에서 레코드가 삭제되지 않고, is_deleted 칼럼이 true로 set된다.
+     * @param commentId 논리 삭제를 수행할 대상 entity
+     * @return commentId에 해당하는 Comment entity가 존재해서 삭제에 성공하면 true, 그렇지 않으면 false
+     */
+    public boolean deleteById(Long commentId) {
+        Optional<Comment> commentOp = this.commentJpaRepository.findById(commentId);
+        if (commentOp.isEmpty()) {
+            return false;
+        }
+        Comment comment = commentOp.get();
+        comment.setDeleted(true);
+        return true;
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.hf.healthfriend.domain.comment.entity.Comment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -28,5 +29,9 @@ public class CommentRepository {
         Comment comment = commentOp.get();
         comment.setDeleted(true);
         return true;
+    }
+
+    public List<Comment> findCommentsByPostId(Long postId) {
+        return this.commentJpaRepository.findByPostId(postId);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/repository/dto/CommentUpdateDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/repository/dto/CommentUpdateDto.java
@@ -1,0 +1,12 @@
+package com.hf.healthfriend.domain.comment.repository.dto;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class CommentUpdateDto {
+    private String content;
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -1,0 +1,39 @@
+package com.hf.healthfriend.domain.comment.service;
+
+import com.hf.healthfriend.domain.comment.dto.CommentDto;
+import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
+import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.repository.CommentRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    public CommentCreationResponseDto createComment(Long postId, CommentCreationRequestDto requestDto)
+            throws DataIntegrityViolationException {
+        Comment toSave = new Comment(
+                Post.builder().postId(postId).build(),
+                new Member(requestDto.getWriterId()),
+                requestDto.getContent()
+        );
+        Comment newComment = this.commentRepository.save(toSave);
+        log.info("[Comment Creation] postId={}, commenterId={}", postId, requestDto.getWriterId());
+
+        return CommentCreationResponseDto.builder()
+                .commentId(newComment.getCommentId())
+                .postId(newComment.getPost().getPostId())
+                .writerId(newComment.getWriter().getId())
+                .content(newComment.getContent())
+                .creationTime(newComment.getCreationTime())
+                .build();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -53,4 +53,11 @@ public class CommentService {
                 .map(CommentDto::of)
                 .toList();
     }
+
+    public List<CommentDto> getCommentsOfWriter(Long writerId) { // TODO: 존재하지 않는 Member일 경우 어떻게?
+        return this.commentRepository.findCommentsByWriterId(writerId)
+                .stream()
+                .map(CommentDto::of)
+                .toList();
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -13,12 +13,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentService {
     private final CommentRepository commentRepository;
 

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.comment.service;
 
+import com.hf.healthfriend.domain.comment.dto.CommentDto;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.entity.Comment;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Slf4j
@@ -43,5 +45,12 @@ public class CommentService {
         if (!success) {
             throw new NoSuchElementException();
         }
+    }
+
+    public List<CommentDto> getCommentsOfPost(Long postId) { // TODO: postId에 해당하는 Post가 없을 경우 어떻게?
+        return this.commentRepository.findCommentsByPostId(postId)
+                .stream()
+                .map(CommentDto::of)
+                .toList();
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.hf.healthfriend.domain.comment.dto.CommentDto;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
 import com.hf.healthfriend.domain.comment.repository.CommentRepository;
 import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import com.hf.healthfriend.domain.member.entity.Member;
@@ -14,7 +15,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -41,11 +41,8 @@ public class CommentService {
                 .build();
     }
 
-    public void deleteComment(Long commentId) throws NoSuchElementException { // TODO: NoSuchElementException이 맞을까?
-        boolean success = this.commentRepository.deleteById(commentId);
-        if (!success) {
-            throw new NoSuchElementException();
-        }
+    public void deleteComment(Long commentId) throws CommentNotFoundException {
+        this.commentRepository.deleteById(commentId);
     }
 
     public List<CommentDto> getCommentsOfPost(Long postId) { // TODO: postId에 해당하는 Post가 없을 경우 어떻게?
@@ -62,7 +59,7 @@ public class CommentService {
                 .toList();
     }
 
-    public CommentDto updateComment(Long commentId, CommentUpdateDto updateDto) {
+    public CommentDto updateComment(Long commentId, CommentUpdateDto updateDto) throws CommentNotFoundException {
         Comment updatedComment = this.commentRepository.updateComment(commentId, updateDto);
         return CommentDto.of(updatedComment);
     }

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -1,6 +1,5 @@
 package com.hf.healthfriend.domain.comment.service;
 
-import com.hf.healthfriend.domain.comment.dto.CommentDto;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.entity.Comment;
@@ -11,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -35,5 +36,12 @@ public class CommentService {
                 .content(newComment.getContent())
                 .creationTime(newComment.getCreationTime())
                 .build();
+    }
+
+    public void deleteComment(Long commentId) throws NoSuchElementException { // TODO: NoSuchElementException이 맞을까?
+        boolean success = this.commentRepository.deleteById(commentId);
+        if (!success) {
+            throw new NoSuchElementException();
+        }
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.entity.Comment;
 import com.hf.healthfriend.domain.comment.repository.CommentRepository;
+import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.post.entity.Post;
 import lombok.RequiredArgsConstructor;
@@ -59,5 +60,10 @@ public class CommentService {
                 .stream()
                 .map(CommentDto::of)
                 .toList();
+    }
+
+    public CommentDto updateComment(Long commentId, CommentUpdateDto updateDto) {
+        Comment updatedComment = this.commentRepository.updateComment(commentId, updateDto);
+        return CommentDto.of(updatedComment);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
@@ -27,7 +27,7 @@ public class MemberAccessController {
 
     private final MemberRepository memberRepository;
 
-    @AccessControlTrigger(path = "/members", method = "POST")
+    @AccessControlTrigger(path = "/hr/members", method = "POST")
     public boolean preventSignUpByOtherClient(BearerTokenAuthentication authentication, HttpServletRequest request)
             throws ServletException, IOException {
         Part idPart = request.getPart("loginId");
@@ -49,12 +49,12 @@ public class MemberAccessController {
         return authenticatedMemberId.equals(id.trim());
     }
 
-    @AccessControlTrigger(path = "/members/{memberId}", method = "GET")
+    @AccessControlTrigger(path = "/hr/members/{memberId}", method = "GET")
     public boolean controlAccessToMemberInfo(BearerTokenAuthentication authentication, HttpServletRequest request) {
         return accessControl(authentication, request);
     }
 
-    @AccessControlTrigger(path = "/members/{memberId}", method = "PATCH")
+    @AccessControlTrigger(path = "/hr/members/{memberId}", method = "PATCH")
     public boolean accessControlForUpdateMember(BearerTokenAuthentication authentication, HttpServletRequest request) {
         return accessControl(authentication, request);
     }

--- a/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
@@ -3,12 +3,9 @@ package com.hf.healthfriend.domain.member.accesscontrol;
 import com.hf.healthfriend.auth.accesscontrol.AccessControlTrigger;
 import com.hf.healthfriend.auth.accesscontrol.AccessController;
 import com.hf.healthfriend.domain.member.constant.Role;
-import com.hf.healthfriend.domain.member.entity.Member;
-import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
@@ -17,15 +14,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @AccessController
-@RequiredArgsConstructor
 public class MemberAccessController {
     private static final int BUFFER_SIZE = 256;
-
-    private final MemberRepository memberRepository;
 
     @AccessControlTrigger(path = "/hr/members", method = "POST")
     public boolean preventSignUpByOtherClient(BearerTokenAuthentication authentication, HttpServletRequest request)
@@ -45,6 +38,8 @@ public class MemberAccessController {
         log.trace("id={}", id);
 
         String authenticatedMemberId = authentication.getName(); // null이면 이미 401이 났을 테니 null이 아닐 것
+
+        log.trace("authenticatedMemberId={}", authenticatedMemberId);
 
         return authenticatedMemberId.equals(id.trim());
     }
@@ -70,20 +65,14 @@ public class MemberAccessController {
         }
 
         String path = request.getRequestURI();
-        long resourceMemberId = Long.parseLong(path.substring(path.lastIndexOf('/') + 1));
-
-        Optional<Member> findMemberOp = memberRepository.findById(resourceMemberId);
-
-        if (findMemberOp.isEmpty()) {
-            return true;
-        }
+        String resourceMemberId = path.substring(path.lastIndexOf('/') + 1);
 
         if (log.isTraceEnabled()) {
             log.trace("path={}", path);
             log.trace("pathVariable={}", resourceMemberId);
             log.trace("authentication.getName()={}", authentication.getName());
-            log.trace("findMemberOp.get().getLoginId().equals(authentication.getName())={}", findMemberOp.get().getLoginId().equals(authentication.getName()));
+            log.trace("resourceMemberId.equals(authentication.getName())={}", resourceMemberId.equals(authentication.getName()));
         }
-        return findMemberOp.get().getLoginId().equals(authentication.getName());
+        return resourceMemberId.equals(authentication.getName());
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/accesscontrol/MemberAccessController.java
@@ -30,7 +30,7 @@ public class MemberAccessController {
     @AccessControlTrigger(path = "/hr/members", method = "POST")
     public boolean preventSignUpByOtherClient(BearerTokenAuthentication authentication, HttpServletRequest request)
             throws ServletException, IOException {
-        Part idPart = request.getPart("loginId");
+        Part idPart = request.getPart("id");
         String id;
 
         try (BufferedReader br = new BufferedReader(new InputStreamReader(idPart.getInputStream()))) {

--- a/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
@@ -113,7 +113,7 @@ public class MemberController {
                     )
             )
     })
-    public ResponseEntity<ApiBasicResponse<MemberDto>> findMember(@PathVariable String memberId) {
+    public ResponseEntity<ApiBasicResponse<MemberDto>> findMember(@PathVariable Long memberId) {
         log.info("Find member of id={}", memberId);
         return ResponseEntity.ok(ApiBasicResponse.of(this.memberService.findMember(memberId), HttpStatus.OK));
     }
@@ -143,7 +143,7 @@ public class MemberController {
                     )
             )
     })
-    public ResponseEntity<ApiBasicResponse<MemberDto>> updateMember(@PathVariable String memberId,
+    public ResponseEntity<ApiBasicResponse<MemberDto>> updateMember(@PathVariable Long memberId,
                                                                     @ModelAttribute MemberUpdateRequestDto dto) {
         MemberDto resultDto = this.memberService.updateMember(memberId, dto);
         return ResponseEntity.ok(ApiBasicResponse.of(resultDto, HttpStatus.OK));

--- a/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
@@ -29,7 +29,7 @@ import java.net.URISyntaxException;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
+@RequestMapping("/hr/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -84,7 +84,7 @@ public class MemberController {
         log.info("Request Body:\n{}", requestBody);
 
         MemberCreationResponseDto result = this.memberService.createMember(requestBody);
-        return ResponseEntity.created(new URI("/members/" + result.getMemberId()))
+        return ResponseEntity.created(new URI("/hr/members/" + result.getMemberId()))
                 .body(ApiBasicResponse.of(result, HttpStatus.CREATED));
     }
 
@@ -113,7 +113,7 @@ public class MemberController {
                     )
             )
     })
-    public ResponseEntity<ApiBasicResponse<MemberDto>> findMember(@PathVariable Long memberId) {
+    public ResponseEntity<ApiBasicResponse<MemberDto>> findMember(@PathVariable("memberId") Long memberId) {
         log.info("Find member of id={}", memberId);
         return ResponseEntity.ok(ApiBasicResponse.of(this.memberService.findMember(memberId), HttpStatus.OK));
     }
@@ -143,7 +143,7 @@ public class MemberController {
                     )
             )
     })
-    public ResponseEntity<ApiBasicResponse<MemberDto>> updateMember(@PathVariable Long memberId,
+    public ResponseEntity<ApiBasicResponse<MemberDto>> updateMember(@PathVariable("memberId") Long memberId,
                                                                     @ModelAttribute MemberUpdateRequestDto dto) {
         MemberDto resultDto = this.memberService.updateMember(memberId, dto);
         return ResponseEntity.ok(ApiBasicResponse.of(resultDto, HttpStatus.OK));

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
@@ -12,7 +12,8 @@ import java.time.LocalDateTime;
 @Getter
 @ToString
 public class MemberDto {
-    private String memberId;
+    private Long memberId;
+    private String loginId;
     private Role role;
     private String email;
     private LocalDateTime creationTime;

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 public class MemberCreationRequestDto {
 
     @Schema(description = "생성할 회원의 ID. 소셜 로그인일 경우 id와 email은 같다. email은 id로 설정된다.")
-    private String id;
+    private String loginId;
 
     private String nickname;
 

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 public class MemberCreationRequestDto {
 
     @Schema(description = "생성할 회원의 ID. 소셜 로그인일 경우 id와 email은 같다. email은 id로 설정된다.")
-    private String loginId;
+    private String id;
 
     private String nickname;
 

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberCreationResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberCreationResponseDto.java
@@ -14,8 +14,11 @@ import java.time.LocalDateTime;
 @ToString
 public class MemberCreationResponseDto {
 
-    @Schema(description = "생성된 회원의 ID. 소셜 로그인일 경우 memberId와 email은 같다.")
-    private final String memberId;
+    @Schema(description = "생성된 회원의 ID")
+    private final Long memberId;
+
+    @Schema(description = "login용 ID. 소셜 로그인일 경우 email과 값이 같다.")
+    private final String loginId;
 
     @Schema(description = "생성된 회원의 Email. 소셜 로그인일 경우 memberId와 email은 같다.")
     private final String email;
@@ -47,6 +50,7 @@ public class MemberCreationResponseDto {
     public static MemberCreationResponseDto of(Member member) {
         return MemberCreationResponseDto.builder()
                 .memberId(member.getId())
+                .loginId(member.getLoginId())
                 .email(member.getEmail())
                 .role(member.getRole().name())
                 .creationTime(member.getCreationTime())

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -22,14 +22,18 @@ import java.util.List;
 public class Member implements UserDetails {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    private String id;
+    private Long id;
+
+    @Column(name = "login_id", unique = true, nullable = false)
+    private String loginId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     private Role role = Role.ROLE_MEMBER;
 
-    @Column(name = "email")
+    @Column(name = "email", unique = true, nullable = false)
     private String email;
 
     @Column(name = "password")
@@ -42,7 +46,7 @@ public class Member implements UserDetails {
     @Column(name = "nickname")
     private String nickname;
 
-    @Column(name = "profile_image_url")
+    @Column(name = "profile_url")
     private String profileImageUrl;
 
     @Column(name = "birth_date")
@@ -79,13 +83,17 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Post> posts = new ArrayList<>();
 
+    public Member(long memberId) {
+        this.id = memberId;
+    }
+
     public Member(String email) {
-        this.id = email;
+        this.loginId = email;
         this.email = email;
     }
 
-    public Member(String id, String email, String password) {
-        this.id = id;
+    public Member(String loginId, String email, String password) {
+        this.loginId = loginId;
         this.email = email;
         this.password = password;
     }
@@ -101,6 +109,6 @@ public class Member implements UserDetails {
 
     @Override
     public String getUsername() {
-        return this.id;
+        return String.valueOf(this.id);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/exception/MemberNotFoundException.java
@@ -12,25 +12,46 @@ import lombok.ToString;
 @Getter
 @ToString
 public class MemberNotFoundException extends RuntimeException {
-    private final String memberId;
+    private Long memberId;
+    private String loginId;
 
-    public MemberNotFoundException(String memberId) {
+    public MemberNotFoundException(Long memberId) {
         super();
         this.memberId = memberId;
     }
 
-    public MemberNotFoundException(String memberId, String message) {
+    public MemberNotFoundException(String loginId) {
+        super();
+        this.loginId = loginId;
+    }
+
+    public MemberNotFoundException(Long memberId, String message) {
         super(message);
         this.memberId = memberId;
     }
 
-    public MemberNotFoundException(String memberId, Throwable cause) {
+    public MemberNotFoundException(String loginId, String message) {
+        super(message);
+        this.loginId = loginId;
+    }
+
+    public MemberNotFoundException(Long memberId, Throwable cause) {
         super(cause);
         this.memberId = memberId;
     }
 
-    public MemberNotFoundException(String memberId, String message, Throwable cause) {
+    public MemberNotFoundException(String loginId, Throwable cause) {
+        super(cause);
+        this.loginId = loginId;
+    }
+
+    public MemberNotFoundException(Long memberId, String message, Throwable cause) {
         super(message, cause);
         this.memberId = memberId;
+    }
+
+    public MemberNotFoundException(String loginId, String message, Throwable cause) {
+        super(message, cause);
+        this.loginId = loginId;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/MemberJpaRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/MemberJpaRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberJpaRepository extends JpaRepository<Member, String> {
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByLoginId(String loginId);
+
     boolean existsByEmail(String email);
+
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepository.java
@@ -9,13 +9,17 @@ public interface MemberRepository {
 
     Member save(Member member);
 
-    Optional<Member> findById(String id);
+    Optional<Member> findById(Long id);
+
+    Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findByEmail(String email);
 
-    boolean existsById(String id);
+    boolean existsById(Long id);
+
+    boolean existsByLoginId(String loginId);
 
     boolean existsByEmail(String email);
 
-    Member update(String memberId, MemberUpdateDto updateDto);
+    Member update(Long memberId, MemberUpdateDto updateDto);
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepositoryImpl.java
@@ -4,10 +4,12 @@ import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import com.hf.healthfriend.domain.member.repository.dto.MemberUpdateDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class MemberRepositoryImpl implements MemberRepository{
@@ -15,12 +17,18 @@ public class MemberRepositoryImpl implements MemberRepository{
 
     @Override
     public Member save(Member member) {
+        log.debug("new member={}", member);
         return this.jpaRepository.save(member);
     }
 
     @Override
-    public Optional<Member> findById(String id) {
+    public Optional<Member> findById(Long id) {
         return this.jpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Member> findByLoginId(String loginId) {
+        return this.jpaRepository.findByLoginId(loginId);
     }
 
     @Override
@@ -29,8 +37,13 @@ public class MemberRepositoryImpl implements MemberRepository{
     }
 
     @Override
-    public boolean existsById(String id) {
+    public boolean existsById(Long id) {
         return this.jpaRepository.existsById(id);
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return this.jpaRepository.existsByLoginId(loginId);
     }
 
     @Override
@@ -39,7 +52,7 @@ public class MemberRepositoryImpl implements MemberRepository{
     }
 
     @Override
-    public Member update(String memberId, MemberUpdateDto updateDto) {
+    public Member update(Long memberId, MemberUpdateDto updateDto) {
         Member member = this.jpaRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -39,11 +39,11 @@ public class MemberService {
      */
     public MemberCreationResponseDto createMember(MemberCreationRequestDto dto)
             throws DuplicateMemberCreationException {
-        if (this.memberRepository.existsByLoginId(dto.getLoginId())) {
-            throw new DuplicateMemberCreationException(dto.getLoginId());
+        if (this.memberRepository.existsByLoginId(dto.getId())) {
+            throw new DuplicateMemberCreationException(dto.getId());
         }
 
-        Member newMember = new Member(dto.getLoginId());
+        Member newMember = new Member(dto.getId());
         BeanUtils.copyProperties(dto, newMember);
         if (log.isDebugEnabled()) {
             log.debug("newMember={}", newMember);

--- a/src/main/java/com/hf/healthfriend/domain/post/dto/request/PostWriteRequest.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/dto/request/PostWriteRequest.java
@@ -20,7 +20,7 @@ public class PostWriteRequest{
     @Size(min = 10, max = 1000, message = "내용은 10자 이상 1000자 이하로 입력해주세요.")
     String content;
     @NotBlank(message="작성자 아이디는 필수값입니다. ")
-    String writerId;
+    Long writerId;
 
     public Post toEntity(Member member){
         PostCategory postCategory = PostCategory.valueOf(category);

--- a/src/main/java/com/hf/healthfriend/domain/post/entity/Post.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/entity/Post.java
@@ -36,7 +36,7 @@ public class Post extends BaseTimeEntity {
     private Boolean isDeleted = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "writer_id")
     private Member member;
 
     public void delete(){

--- a/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
@@ -26,7 +26,7 @@ public class PostService {
     private final MemberRepository memberRepository;
 
     public Long save(PostWriteRequest postWriteRequest) {
-        String memberId = postWriteRequest.getWriterId();
+        Long memberId = postWriteRequest.getWriterId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
         Post post = postWriteRequest.toEntity(member);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
       - secret
       - constants
       - priv # 각각 개발 환경에 따라 개별 설정이 필요할 수 있으므로
-      - local-dev
   servlet:
     multipart:
       enabled: true

--- a/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
@@ -158,7 +158,7 @@ class CommentControllerMockMvcTest {
         CommentCreationResponseDto creationResult = this.commentService.createComment(10000L, requestDto);
 
 
-        this.mockMvc.perform(delete("/hr/comments/{commentId}", creationResult.getCommentId()))
+        this.mockMvc.perform(delete("/hr/comments/{commentId}", creationResult.commentId()))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
@@ -1,0 +1,87 @@
+package com.hf.healthfriend.domain.comment.controller;
+
+import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
+import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.comment.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Slf4j
+@WebMvcTest(CommentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CommentControllerMockMvcTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    CommentService commentService;
+
+    @BeforeEach
+    void beforeEach() {
+        when(this.commentService.createComment(
+                        10000L,
+                        CommentCreationRequestDto.builder()
+                                .content("sample-content")
+                                .writerId(1000L)
+                                .build()
+                )
+        )
+                .thenReturn(
+                        CommentCreationResponseDto.builder()
+                                .commentId(10000L)
+                                .creationTime(LocalDateTime.now())
+                                .postId(10000L)
+                                .writerId(1000L)
+                                .content("sample-content")
+                                .build()
+                );
+    }
+
+    @DisplayName("POST /posts/{postId}/comments - create a comment - 201 expected")
+    @Test
+    void createComment_success() throws Exception {
+        MockHttpServletResponse response = this.mockMvc.perform(post("/hr/posts/{postId}/comments", 10000L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "writerId": 1000,
+                                    "content": "sample-content"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(content().json("""
+                        {
+                            "statusCode": 201,
+                            "statusCodeSeries": 2,
+                            "content": {
+                                "postId": 10000,
+                                "writerId": 1000,
+                                "content": "sample-content"
+                            }
+                        }
+                        """))
+                .andReturn()
+                .getResponse();
+        log.info("Response status={}", response.getStatus());
+        log.info("Response Location Header={}", response.getHeader(HttpHeaders.LOCATION));
+        log.info("Response body:\n{}", response.getContentAsString());
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
@@ -88,6 +88,32 @@ class CommentControllerMockMvcTest {
                                         .build()
                         )
                 );
+        when(this.commentService.getCommentsOfWriter(10000L))
+                .thenReturn(
+                        List.of(
+                                CommentDto.builder()
+                                        .commentId(1L)
+                                        .postId(1000L)
+                                        .writerId(10000L)
+                                        .content("sample1")
+                                        .creationTime(LocalDateTime.now())
+                                        .build(),
+                                CommentDto.builder()
+                                        .commentId(2L)
+                                        .postId(1000L)
+                                        .writerId(10000L)
+                                        .content("sample2")
+                                        .creationTime(LocalDateTime.now())
+                                        .build(),
+                                CommentDto.builder()
+                                        .commentId(3L)
+                                        .postId(1001L)
+                                        .writerId(10000L)
+                                        .content("sample3")
+                                        .creationTime(LocalDateTime.now())
+                                        .build()
+                        )
+                );
     }
 
     @DisplayName("POST /posts/{postId}/comments - create a comment - 201 expected")
@@ -143,6 +169,24 @@ class CommentControllerMockMvcTest {
     @Test
     void findCommentsOfSpecificPost() throws Exception {
         String responseBodyAsString = this.mockMvc.perform(get("/hr/posts/{postId}/comments", 10000L)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsString();
+
+        log.info("responseBodyAsString:\n{}", responseBodyAsString);
+        ApiBasicResponse<List<CommentDto>> responseBody = this.objectMapper.readValue(responseBodyAsString, new TypeReference<ApiBasicResponse<List<CommentDto>>>() {
+        });
+
+        assertThat(responseBody.getStatusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(responseBody.getStatusCodeSeries()).isEqualTo(HttpStatus.OK.series().value());
+        assertThat(responseBody.getContent()).size().isEqualTo(3);
+    }
+
+
+    @DisplayName("GET /comments?writerId= - 조회 성공")
+    @Test
+    void findCommentsOfSpecificWriter() throws Exception {
+        String responseBodyAsString = this.mockMvc.perform(get("/hr/comments")
+                        .param("writerId", String.valueOf(10000))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse().getContentAsString();
 

--- a/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/controller/CommentControllerMockMvcTest.java
@@ -3,6 +3,7 @@ package com.hf.healthfriend.domain.comment.controller;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.service.CommentService;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -19,12 +21,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Slf4j
 @WebMvcTest(CommentController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
 class CommentControllerMockMvcTest {
 
     @Autowired
@@ -83,5 +87,20 @@ class CommentControllerMockMvcTest {
         log.info("Response status={}", response.getStatus());
         log.info("Response Location Header={}", response.getHeader(HttpHeaders.LOCATION));
         log.info("Response body:\n{}", response.getContentAsString());
+    }
+
+    @SneakyThrows
+    @DisplayName("DELETE /comments/{commentId} - 삭제 성공")
+    @Test
+    void deleteComment_success() {
+        CommentCreationRequestDto requestDto = CommentCreationRequestDto.builder()
+                .content("sample-content")
+                .writerId(1000L)
+                .build();
+        CommentCreationResponseDto creationResult = this.commentService.createComment(10000L, requestDto);
+
+
+        this.mockMvc.perform(delete("/hr/comments/{commentId}", creationResult.getCommentId()))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.comment.repository;
 
 import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
 import com.hf.healthfriend.domain.comment.repository.dto.CommentUpdateDto;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
@@ -23,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -263,8 +263,8 @@ class TestCommentRepository {
 
     @DisplayName("updateComment - 그런 comment 없어서 수정 실패")
     @Test
-    void updateComment_fail_sinceNoSuchCommentOfCommentId() {
-        assertThatExceptionOfType(NoSuchElementException.class)
+    void updateComment_fail_sinceCommentNotFoundException() {
+        assertThatExceptionOfType(CommentNotFoundException.class)
                 .isThrownBy(() -> this.commentRepository.updateComment(11351L, CommentUpdateDto.builder().content("New Content").build()));
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
@@ -100,6 +100,16 @@ class TestCommentRepository {
         entity.setFitnessKind(FitnessKind.FUNCTIONAL);
     }
 
+    @DisplayName("findById - 삭제된 레코드는 가져오지 않음")
+    @Test
+    void findById_ignoreDeleted() {
+        Comment comment =
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(0)), "content1");
+        Long generatedId = this.commentRepository.save(comment).getCommentId();
+        this.commentRepository.deleteById(generatedId);
+        assertThat(this.commentRepository.findById(generatedId)).isEmpty();
+    }
+
     @DisplayName("findCommentsByPostId - 다 찾아옴")
     @Test
     void findCommentsByPostId_findAll() {
@@ -266,5 +276,18 @@ class TestCommentRepository {
     void updateComment_fail_sinceCommentNotFoundException() {
         assertThatExceptionOfType(CommentNotFoundException.class)
                 .isThrownBy(() -> this.commentRepository.updateComment(11351L, CommentUpdateDto.builder().content("New Content").build()));
+    }
+
+    @DisplayName("deleteById - 삭제된 엔티티를 또 삭제하려고 하면 CommentNotFoundException 발생")
+    @Test
+    void deleteById_failWhenAttemptsToDeleteDeletedComment() {
+        Comment comment = new Comment(Post.builder().postId(this.postId).build(),
+                new Member(this.commentWriterIds.get(0)),
+                "content1");
+        Long generatedId = this.commentRepository.save(comment).getCommentId();
+        this.commentRepository.deleteById(generatedId);
+
+        assertThatExceptionOfType(CommentNotFoundException.class)
+                .isThrownBy(() -> this.commentRepository.deleteById(generatedId));
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/repository/TestCommentRepository.java
@@ -1,0 +1,164 @@
+package com.hf.healthfriend.domain.comment.repository;
+
+import com.hf.healthfriend.domain.comment.entity.Comment;
+import com.hf.healthfriend.domain.member.constant.*;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.domain.post.constant.PostCategory;
+import com.hf.healthfriend.domain.post.entity.Post;
+import com.hf.healthfriend.domain.post.repository.PostRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+@ActiveProfiles({
+        "local-dev",
+        "secret",
+        "constants",
+        "priv"
+})
+class TestCommentRepository {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    Long postWriterId;
+
+    List<Long> commentWriterIds;
+
+    Long postId;
+
+    @BeforeEach
+    void beforeEach() {
+        // Insert sample members
+        Member postWriter = new Member("post@writer.com");
+        setNecessaryFieldOfMemberToSampleData(postWriter, "샘플포스터");
+
+        this.postWriterId = this.memberRepository.save(postWriter).getId();
+
+        List<Member> commentWriters = List.of(
+                new Member("comment1@writer.com"),
+                new Member("comment2@writer.com"),
+                new Member("comment3@writer.com")
+        );
+        commentWriters.forEach((e) -> {
+            setNecessaryFieldOfMemberToSampleData(e, e.getLoginId().substring(0, 8));
+            this.memberRepository.save(e);
+        });
+
+        this.commentWriterIds = commentWriters.stream().map(Member::getId).toList();
+
+        // Insert sample post
+        Post post = Post.builder()
+                .content("sample-post")
+                .title("sample-title")
+                .category(PostCategory.COUNSELING)
+                .member(postWriter)
+                .build();
+
+        this.postRepository.save(post);
+
+        this.postId = post.getPostId();
+    }
+
+    private void setNecessaryFieldOfMemberToSampleData(Member entity, String sampleNickname) {
+        entity.setNickname(sampleNickname);
+        entity.setBirthDate(LocalDate.of(1997, 9, 16));
+        entity.setGender(Gender.MALE);
+        entity.setIntroduction("");
+        entity.setFitnessLevel(FitnessLevel.ADVANCED);
+        entity.setCompanionStyle(CompanionStyle.SMALL);
+        entity.setFitnessEagerness(FitnessEagerness.EAGER);
+        entity.setFitnessObjective(FitnessObjective.BULK_UP);
+        entity.setFitnessKind(FitnessKind.FUNCTIONAL);
+    }
+
+    @DisplayName("findCommentsByPostId - 다 찾아옴")
+    @Test
+    void findCommentsByPostId_findAll() {
+        // Given
+        List<Comment> commentsToInsert = List.of(
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(0)), "content1"),
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(1)), "content2"),
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(2)), "content3")
+        );
+
+        commentsToInsert.forEach((c) -> this.commentRepository.save(c));
+
+        // When
+        long postIdToQuery = this.postId;
+
+        // Then
+        List<Comment> result = this.commentRepository.findCommentsByPostId(postIdToQuery);
+
+        log.info("result={}", result);
+
+        assertThat(result).size().isEqualTo(3);
+        assertThat(result.stream().map((c) -> c.getWriter().getId()).toList()).containsExactlyInAnyOrder(
+                this.commentWriterIds.toArray(Long[]::new)
+        );
+
+        result.forEach((c) -> assertThat(c.getPost().getPostId()).isEqualTo(this.postId));
+    }
+
+    static Stream<Arguments> findCommentsByPostId_excludeDeleted() {
+        // Arguments의 첫 번째 값은 this.commentRepository.findCommentsByPostId 메소드의
+        // size 예상값
+        // 두 번째 이후의 값은 삭제할 Comment의 indices
+        return Stream.of(
+                Arguments.of(2, new int[] { 0 }),
+                Arguments.of(2, new int[] { 1 }),
+                Arguments.of(2, new int[] { 2 }),
+                Arguments.of(1, new int[] { 0, 2 }),
+                Arguments.of(0, new int[] { 0, 1, 2 })
+        );
+    }
+
+    @DisplayName("findCommentsByPostId - isDeleted = true 인 거 제외하는 거 체크")
+    @MethodSource
+    @ParameterizedTest
+    void findCommentsByPostId_excludeDeleted(int expectedSize, int[] indicesOfCommentsToDelete) {
+        // Given
+        List<Comment> commentsToInsert = List.of(
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(0)), "content1"),
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(1)), "content2"),
+                new Comment(Post.builder().postId(this.postId).build(), new Member(this.commentWriterIds.get(2)), "content3")
+        );
+
+        commentsToInsert.forEach((c) -> this.commentRepository.save(c));
+
+        for (int indexOfCommentToDelete : indicesOfCommentsToDelete) {
+            this.commentRepository.deleteById(commentsToInsert.get(indexOfCommentToDelete).getCommentId());
+        }
+
+        // Then
+        List<Comment> result = this.commentRepository.findCommentsByPostId(this.postId);
+
+        log.info("result={}", result);
+
+        assertThat(result).size().isEqualTo(expectedSize);
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
@@ -1,0 +1,121 @@
+package com.hf.healthfriend.domain.comment.service;
+
+import com.hf.healthfriend.domain.comment.dto.CommentDto;
+import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
+import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.domain.post.constant.PostCategory;
+import com.hf.healthfriend.domain.post.entity.Post;
+import com.hf.healthfriend.domain.post.repository.PostRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+class TestCommentService {
+
+    @Autowired
+    CommentService commentService;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("createComment - 생성 성공")
+    @Test
+    void createComment_succeededToCreate() {
+        // Given
+        Member postWriter = new Member("sample@post.writer");
+        Member commentWriter = new Member("sample@comment.writer");
+
+        this.memberRepository.save(commentWriter);
+        this.memberRepository.save(postWriter);
+
+        Post post = Post.builder()
+                .title("sample-post")
+                .category(PostCategory.WORKOUT_CERTIFICATION)
+                .creationTime(LocalDateTime.now())
+                .member(postWriter)
+                .build();
+
+        this.postRepository.save(post);
+        log.info("post={}", post);
+
+        // When
+        CommentCreationRequestDto requestDto = CommentCreationRequestDto.builder()
+                .writerId(commentWriter.getId())
+                .content("sample-comment")
+                .build();
+
+        LocalDateTime beforeStart = LocalDateTime.now();
+
+        // Then
+        CommentCreationResponseDto result = this.commentService.createComment(post.getPostId(), requestDto);
+        log.info("result={}", result);
+
+        assertThat(result.getPostId()).isEqualTo(post.getPostId());
+        assertThat(result.getWriterId()).isEqualTo(commentWriter.getId());
+        assertThat(result.getContent()).isEqualTo("sample-comment");
+        assertThat(result.getCreationTime()).isAfterOrEqualTo(beforeStart);
+    }
+
+    @DisplayName("createComment - 생성 실패 - post is null")
+    @Test
+    void createComment_fail_sincePostIsNull_DataIntegrityViolationException() {
+        // Given
+        Member commentWriter = new Member("comment@writer.com");
+        this.memberRepository.save(commentWriter);
+
+        // When
+        CommentCreationRequestDto requestDto = CommentCreationRequestDto.builder()
+                .writerId(commentWriter.getId())
+                .content("sample-content")
+                .build();
+
+        // Then
+        assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
+                .isThrownBy(() -> this.commentService.createComment(null, requestDto));
+    }
+
+    @DisplayName("createcomment - 생성 실패 - DB에 없는 회원 ID로 생성")
+    @Test
+    void createComment_fail_sinceTransientMember_DataIntegrityViolationException() {
+        // Given
+        Member postWriter = new Member("sample@post.writer");
+        this.memberRepository.save(postWriter);
+
+        Post post = Post.builder()
+                .title("sample-post")
+                .category(PostCategory.WORKOUT_CERTIFICATION)
+                .creationTime(LocalDateTime.now())
+                .member(postWriter)
+                .build();
+
+        this.postRepository.save(post);
+
+        // When
+        CommentCreationRequestDto requestDto = CommentCreationRequestDto.builder()
+                .writerId(23518524L)
+                .content("good-content")
+                .build();
+
+        // Then
+        assertThatExceptionOfType(DataIntegrityViolationException.class)
+                .isThrownBy(() -> this.commentService.createComment(post.getPostId(), requestDto));
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
@@ -3,7 +3,6 @@ package com.hf.healthfriend.domain.comment.service;
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
 import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
-import com.hf.healthfriend.domain.comment.repository.CommentRepository;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
@@ -22,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
@@ -2,6 +2,7 @@ package com.hf.healthfriend.domain.comment.service;
 
 import com.hf.healthfriend.domain.comment.dto.request.CommentCreationRequestDto;
 import com.hf.healthfriend.domain.comment.dto.response.CommentCreationResponseDto;
+import com.hf.healthfriend.domain.comment.exception.CommentNotFoundException;
 import com.hf.healthfriend.domain.comment.repository.CommentRepository;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
@@ -187,7 +188,7 @@ class TestCommentService {
     @DisplayName("deleteComment - 없는 Comment를 삭제하려고 해서 실패")
     @Test
     void deleteComment_fail_noSuchElementException() {
-        assertThatExceptionOfType(NoSuchElementException.class)
+        assertThatExceptionOfType(CommentNotFoundException.class)
                 .isThrownBy(() -> this.commentService.deleteComment(1000L));
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
+++ b/src/test/java/com/hf/healthfriend/domain/comment/service/TestCommentService.java
@@ -78,10 +78,10 @@ class TestCommentService {
         CommentCreationResponseDto result = this.commentService.createComment(post.getPostId(), requestDto);
         log.info("result={}", result);
 
-        assertThat(result.getPostId()).isEqualTo(post.getPostId());
-        assertThat(result.getWriterId()).isEqualTo(commentWriter.getId());
-        assertThat(result.getContent()).isEqualTo("sample-comment");
-        assertThat(result.getCreationTime()).isAfterOrEqualTo(beforeStart);
+        assertThat(result.postId()).isEqualTo(post.getPostId());
+        assertThat(result.writerId()).isEqualTo(commentWriter.getId());
+        assertThat(result.content()).isEqualTo("sample-comment");
+        assertThat(result.creationTime()).isAfterOrEqualTo(beforeStart);
     }
 
     @DisplayName("createComment - 생성 실패 - post is null")
@@ -176,11 +176,11 @@ class TestCommentService {
         log.info("result={}", result);
 
         // When
-        Long newCommentId = result.getCommentId();
+        Long newCommentId = result.commentId();
 
         // Then
         assertThatNoException()
-                .isThrownBy(() -> this.commentService.deleteComment(result.getCommentId()));
+                .isThrownBy(() -> this.commentService.deleteComment(result.commentId()));
     }
 
     @DisplayName("deleteComment - 없는 Comment를 삭제하려고 해서 실패")

--- a/src/test/java/com/hf/healthfriend/domain/member/controller/TestMemberController.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/controller/TestMemberController.java
@@ -73,10 +73,10 @@ class TestMemberController {
                 .build();
     }
 
-    @DisplayName("POST /members - success")
+    @DisplayName("POST /hr/members - success")
     @Test
     void memberCreation_success() throws Exception {
-        this.mockMvc.perform(multipart("/members")
+        this.mockMvc.perform(multipart("/hr/members")
                         .param("loginId", "new@gmail.com")
                         .param("nickname", "새로운인간")
                         .param("birthDate", "1997-09-16")
@@ -107,10 +107,10 @@ class TestMemberController {
 
     }
 
-    @DisplayName("POST /members - failure")
+    @DisplayName("POST /hr/members - failure")
     @Test
     void memberCreation_failure() throws Exception {
-        this.mockMvc.perform(multipart("/members")
+        this.mockMvc.perform(multipart("/hr/members")
                         .param("loginId", "sample@gmail.com")
                         .param("nickname", "샘플닉네임")
                         .param("birthDate", "1997-09-16")
@@ -134,10 +134,11 @@ class TestMemberController {
                         """));
     }
 
-    @DisplayName("GET /members/{memberId} - succeess to find member")
+    @DisplayName("GET /hr/members/{memberId} - succeess to find member")
     @Test
     void findMember_success() throws Exception {
-        this.mockMvc.perform(get("/members/{memberId}", this.createdMemberId)
+        log.info("createdMemberId={}", this.createdMemberId);
+        this.mockMvc.perform(get("/hr/members/{memberId}", this.createdMemberId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(log())
                 .andDo(print())
@@ -159,10 +160,10 @@ class TestMemberController {
                         """));
     }
 
-    @DisplayName("GET /members/{memberId} - Member not found")
+    @DisplayName("GET /hr/members/{memberId} - Member not found")
     @Test
     void findMember_memberNotFound() throws Exception {
-        this.mockMvc.perform(get("/members/{memberId}", this.createdMemberId + 1)
+        this.mockMvc.perform(get("/hr/members/{memberId}", this.createdMemberId + 1)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(log())
                 .andDo(print())
@@ -177,10 +178,10 @@ class TestMemberController {
                         """));
     }
 
-    @DisplayName("PATCH /members/{memberId} - success")
+    @DisplayName("PATCH /hr/members/{memberId} - success")
     @Test
     void updateMember_success() throws Exception {
-        this.mockMvc.perform(patch("/members/{memberId}", this.createdMemberId)
+        this.mockMvc.perform(patch("/hr/members/{memberId}", this.createdMemberId)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .accept(MediaType.APPLICATION_JSON)
                         .content("{}"))
@@ -195,10 +196,10 @@ class TestMemberController {
                         """));
     }
 
-    @DisplayName("PATCH /members/{memberId} - Member not found")
+    @DisplayName("PATCH /hr/members/{memberId} - Member not found")
     @Test
     void updateMember_memberNotFound() throws Exception {
-        this.mockMvc.perform(patch("/members/{memberId}", this.createdMemberId + 1)
+        this.mockMvc.perform(patch("/hr/members/{memberId}", this.createdMemberId + 1)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .accept(MediaType.APPLICATION_JSON)
                         .content("{}"))

--- a/src/test/java/com/hf/healthfriend/domain/member/controller/TestMemberController.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/controller/TestMemberController.java
@@ -53,7 +53,7 @@ class TestMemberController {
     @BeforeEach
     void beforeEach() {
         MemberCreationRequestDto creationRequestDtoDuplicate = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.of(1997, Month.SEPTEMBER, 16))
                 .gender(Gender.MALE)
@@ -77,7 +77,7 @@ class TestMemberController {
     @Test
     void memberCreation_success() throws Exception {
         this.mockMvc.perform(multipart("/hr/members")
-                        .param("loginId", "new@gmail.com")
+                        .param("id", "new@gmail.com")
                         .param("nickname", "새로운인간")
                         .param("birthDate", "1997-09-16")
                         .param("gender", "MALE")
@@ -111,7 +111,7 @@ class TestMemberController {
     @Test
     void memberCreation_failure() throws Exception {
         this.mockMvc.perform(multipart("/hr/members")
-                        .param("loginId", "sample@gmail.com")
+                        .param("id", "sample@gmail.com")
                         .param("nickname", "샘플닉네임")
                         .param("birthDate", "1997-09-16")
                         .param("gender", "MALE")

--- a/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberJpaRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberJpaRepository.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @Slf4j
 @SpringBootTest
+@Transactional
 public class TestMemberJpaRepository {
 
     @Autowired
@@ -30,16 +32,16 @@ public class TestMemberJpaRepository {
     @DisplayName("findById - 성공 예상")
     @Test
     void findById_successExpected() {
-        String memberId = "sample-member";
+        String loginId = "sample-member";
 
-        Member member = new Member(memberId, "sample@gmail.com", null);
+        Member member = new Member(loginId, "sample@gmail.com", null);
         this.memberJpaRepository.save(member);
 
-        Member findMember = this.memberJpaRepository.findById(memberId).orElseThrow(NoSuchElementException::new);
+        Member findMember = this.memberJpaRepository.findByLoginId(loginId).orElseThrow(NoSuchElementException::new);
 
         log.info("findMember={}", findMember);
 
-        assertThat(findMember.getId()).isEqualTo(memberId);
+        assertThat(findMember.getLoginId()).isEqualTo(loginId);
         assertThat(findMember.getEmail()).isEqualTo("sample@gmail.com");
         assertThat(findMember.getPassword()).isNull();
     }
@@ -47,12 +49,12 @@ public class TestMemberJpaRepository {
     @DisplayName("findById - 아무것도 찾아오지 못함")
     @Test
     void findById_nothingWillBeFetched() {
-        String memberId = "sample-member";
+        String loginId = "sample-member";
 
-        Member member = new Member(memberId, "sample@gmail.com", null);
+        Member member = new Member(loginId, "sample@gmail.com", null);
         this.memberJpaRepository.save(member);
 
-        Optional<Member> findMemberOp = this.memberJpaRepository.findById(memberId + "SUFFIX");
+        Optional<Member> findMemberOp = this.memberJpaRepository.findByLoginId(loginId + "SUFFIX");
 
         assertThat(findMemberOp).isEmpty();
     }

--- a/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberJpaRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberJpaRepository.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.member.repository;
 
+import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -26,6 +28,7 @@ public class TestMemberJpaRepository {
     @Test
     void save() {
         Member member = new Member("sample-member", "sample@gmail.com", null);
+        setRequiredFieldsOfMemberWithWeirdData(member);
         assertThatNoException().isThrownBy(() -> this.memberJpaRepository.save(member));
     }
 
@@ -35,6 +38,7 @@ public class TestMemberJpaRepository {
         String loginId = "sample-member";
 
         Member member = new Member(loginId, "sample@gmail.com", null);
+        setRequiredFieldsOfMemberWithWeirdData(member);
         this.memberJpaRepository.save(member);
 
         Member findMember = this.memberJpaRepository.findByLoginId(loginId).orElseThrow(NoSuchElementException::new);
@@ -52,10 +56,23 @@ public class TestMemberJpaRepository {
         String loginId = "sample-member";
 
         Member member = new Member(loginId, "sample@gmail.com", null);
+        setRequiredFieldsOfMemberWithWeirdData(member);
         this.memberJpaRepository.save(member);
 
         Optional<Member> findMemberOp = this.memberJpaRepository.findByLoginId(loginId + "SUFFIX");
 
         assertThat(findMemberOp).isEmpty();
+    }
+
+    private void setRequiredFieldsOfMemberWithWeirdData(Member member) {
+        member.setNickname("sample-nickname");
+        member.setBirthDate(LocalDate.of(1997, 9, 16));
+        member.setGender(Gender.MALE);
+        member.setIntroduction("안심하세요. 도둑입니다.");
+        member.setFitnessLevel(FitnessLevel.ADVANCED);
+        member.setCompanionStyle(CompanionStyle.GROUP);
+        member.setFitnessObjective(FitnessObjective.RUNNING);
+        member.setFitnessEagerness(FitnessEagerness.EAGER);
+        member.setFitnessKind(FitnessKind.FUNCTIONAL);
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.InvocationTargetException;
@@ -32,6 +33,12 @@ import static org.assertj.core.api.Assertions.*;
 
 @Slf4j
 @SpringBootTest
+@ActiveProfiles({
+        "local-dev",
+        "secret",
+        "constants",
+        "priv"
+})
 @Transactional
 class TestMemberService {
 

--- a/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
@@ -45,7 +45,7 @@ class TestMemberService {
     @Test
     void createMember_withEveryData() {
         MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.now())
                 .gender(Gender.MALE)
@@ -111,16 +111,16 @@ class TestMemberService {
     static Stream<MemberCreationRequestDto> createMember_omittedData() {
         return Stream.of(
                 MemberCreationRequestDto.builder()
-                        .loginId("sample@gmail.com")
+                        .id("sample@gmail.com")
                         .build(),
                 MemberCreationRequestDto.builder()
-                        .loginId("elpmas@khu.ac.kr")
+                        .id("elpmas@khu.ac.kr")
                         .nickname("샘플닉네임")
                         .birthDate(LocalDate.now())
                         .gender(Gender.FEMALE)
                         .build(),
                 MemberCreationRequestDto.builder()
-                        .loginId("asdf@naver.com")
+                        .id("asdf@naver.com")
                         .fitnessEagerness(FitnessEagerness.LAZY)
                         .build()
         );
@@ -138,7 +138,7 @@ class TestMemberService {
     @Test
     void isMemberExists_returnTrue() {
         MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.now())
                 .gender(Gender.MALE)
@@ -162,7 +162,7 @@ class TestMemberService {
     @Test
     void isMemberExists_returnFalse() {
         MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.now())
                 .gender(Gender.MALE)
@@ -186,7 +186,7 @@ class TestMemberService {
     @Test
     void findMember_success() {
         MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.now())
                 .gender(Gender.MALE)
@@ -205,7 +205,7 @@ class TestMemberService {
 
         log.info("result={}", result);
 
-        assertThat(result.getLoginId()).isEqualTo(requestDto.getLoginId());
+        assertThat(result.getLoginId()).isEqualTo(requestDto.getId());
         assertThat(result.getNickname()).isEqualTo(requestDto.getNickname());
         assertThat(result.getCreationTime()).isAfterOrEqualTo(beforeExecution);
         assertThat(result.getCreationTime()).isBeforeOrEqualTo(LocalDateTime.now());
@@ -276,7 +276,7 @@ class TestMemberService {
     @ParameterizedTest
     void updateMember_success(MemberUpdateRequestDto updateDto) {
         MemberCreationRequestDto requestDto = MemberCreationRequestDto.builder()
-                .loginId("sample@gmail.com")
+                .id("sample@gmail.com")
                 .nickname("샘플닉네임")
                 .birthDate(LocalDate.now())
                 .gender(Gender.MALE)

--- a/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
@@ -126,11 +126,11 @@ class TestMemberService {
         );
     }
 
-    @DisplayName("createMember - 누락된 데이터가 있어도 필수값만 있으면 됨")
+    @DisplayName("createMember - 누락된 데이터가 있으면 삽입 실패 - DataIntegrityViolationException")
     @MethodSource
     @ParameterizedTest
     void createMember_omittedData(MemberCreationRequestDto testcase) {
-        assertThatNoException()
+        assertThatExceptionOfType(DataIntegrityViolationException.class)
                 .isThrownBy(() -> this.memberService.createMember(testcase));
     }
 


### PR DESCRIPTION
# 이슈번호 
#35 

# 개요  
- Member의 memberId를 String 타입에서 Long 타입으로 변경 (테이블 스키마도 같이 변경)
- 인증/인가 로직에 memberId 데이터 타입 변경 반영
- 댓글 entity 정의
- 댓글 관련 CRUD 기능 구현
- 댓글 관련 Access Control 구현
- 회원 API URI에 /hr prefix 덧붙임

# 추가사항
변경 사항이 너무 많네요 죄송합니다 ㅠㅠ 다음부터는 풀 리퀘 나눠서 올리겠습니다