### PR TITLE
Documentation/경력 및 수상 이력 API 문서 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/review/exception/ReviewExceptionHandlerControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/exception/ReviewExceptionHandlerControllerAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static com.hf.healthfriend.domain.review.exception.ReviewErrorCode.*;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.hf.healthfriend.domain.review")
 public class ReviewExceptionHandlerControllerAdvice {
 
     @ExceptionHandler(MemberNotFoundException.class)

--- a/src/main/java/com/hf/healthfriend/domain/spec/controller/SpecController.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/controller/SpecController.java
@@ -1,10 +1,21 @@
 package com.hf.healthfriend.domain.spec.controller;
 
+import com.hf.healthfriend.domain.spec.controller.schema.ListSpecDtoSchema;
+import com.hf.healthfriend.domain.spec.controller.schema.SpecUpdateRequestDtoListSchema;
+import com.hf.healthfriend.domain.spec.controller.schema.SpecUpdateResponseDtoSchema;
 import com.hf.healthfriend.domain.spec.dto.SpecDto;
 import com.hf.healthfriend.domain.spec.dto.request.SpecUpdateRequestDto;
 import com.hf.healthfriend.domain.spec.dto.response.SpecUpdateResponseDto;
 import com.hf.healthfriend.domain.spec.service.SpecService;
 import com.hf.healthfriend.global.spec.ApiBasicResponse;
+import com.hf.healthfriend.global.spec.BasicErrorResponse;
+import com.hf.healthfriend.global.spec.schema.LongTypeListSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +33,81 @@ public class SpecController {
     private final SpecService specService;
 
     @PostMapping("/members/{memberId}/specs")
+    @Operation(
+            summary = "경력 및 수상 이력 추가",
+            parameters = @Parameter(
+                    name = "회원 ID",
+                    required = true,
+                    example = "20000"
+            ),
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            schema = @Schema(implementation = ListSpecDtoSchema.class),
+                            examples = @ExampleObject("""
+                                    [
+                                        {
+                                            "startDate": "2017-11-23",
+                                            "endDate": "2018-11-12",
+                                            "isCurrent": false,
+                                            "title": "경력1",
+                                            "description": "종료된 경력"
+                                        },
+                                        {
+                                            "startDate": "2024-08-24",
+                                            "endDate": null,
+                                            "isCurrent": true,
+                                            "title": "경력2",
+                                            "description": "현재 진행 중인 경력"
+                                        },
+                                        {
+                                            "startDate": "2020-11-23",
+                                            "endDate": null,
+                                            "isCurrent": false,
+                                            "title": "수상1",
+                                            "description": ""
+                                        }
+                                    ]
+                                    """)
+
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "경력 및 수상 이력 등록 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = LongTypeListSchema.class),
+                                    examples = @ExampleObject("""
+                                            {
+                                                "statusCode": 201,
+                                                "statusCodeSeries": 2,
+                                                "content": [
+                                                    10000,
+                                                    10001,
+                                                    10002
+                                                ]
+                                            }
+                                            """)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "존재하지 않는 회원에 대한 경력 추가를 시도할 경우",
+                            content = @Content(
+                                    schema = @Schema(implementation = BasicErrorResponse.class),
+                                    examples = @ExampleObject("""
+                                            {
+                                                "errorCode": "SP001",
+                                                "statusCode": 40400,
+                                                "message": "해당 회원이 존재하지 않습니다",
+                                                "errorName": "MEMBER_NOT_FOUND",
+                                                "statusCodeSeries": 4
+                                            }
+                                            """)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<ApiBasicResponse<List<Long>>> addSpecs(@PathVariable("memberId") Long memberId,
                                                                  @RequestBody @Valid List<SpecDto> dtoList) {
         List<Long> result = this.specService.addSpec(memberId, dtoList);
@@ -32,6 +118,73 @@ public class SpecController {
     }
 
     @GetMapping("/members/{memberId}/specs")
+    @Operation(
+            summary = "특정 회원이 가진 경력 및 수상이력 조회",
+            parameters = @Parameter(
+                    name = "회원 ID",
+                    required = true,
+                    example = "10005"
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 조회 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = ListSpecDtoSchema.class),
+                                    examples = @ExampleObject(
+                                            description = "startDate를 기준으로 내림차순 정렬",
+                                            value = """
+                                                    {
+                                                        "statusCode": 200,
+                                                        "statusCodeSeries": 2,
+                                                        content: [
+                                                            {
+                                                                "specId": 879,
+                                                                "startDate": "2019-03-24",
+                                                                "endDate": null,
+                                                                "isCurrent": true,
+                                                                "title": "진행 중인 경력",
+                                                                "description": "현재 진행 중"
+                                                            },
+                                                            {
+                                                                "specId": 1001,
+                                                                "startDate": "2018-01-23",
+                                                                "endDate": null,
+                                                                "isCurrent": false,
+                                                                "title": "수상1",
+                                                                "description": "수상"
+                                                            },
+                                                            {
+                                                                "specId": 1000,
+                                                                "startDate": "2017-01-23",
+                                                                "endDate": "2019-01-25",
+                                                                "isCurrent": false,
+                                                                "title": "경력1",
+                                                                "description": ""
+                                                            }
+                                                        ]
+                                                    }
+                                                    """)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "존재하지 않는 회원에 대한 경력 조회를 시도할 경우",
+                            content = @Content(
+                                    schema = @Schema(implementation = BasicErrorResponse.class),
+                                    examples = @ExampleObject("""
+                                            {
+                                                "errorCode": "SP001",
+                                                "statusCode": 40400,
+                                                "message": "해당 회원이 존재하지 않습니다",
+                                                "errorName": "MEMBER_NOT_FOUND",
+                                                "statusCodeSeries": 4
+                                            }
+                                            """)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<ApiBasicResponse<List<SpecDto>>> getSpecsOfSpecificMember(@PathVariable("memberId") Long memberId) {
         List<SpecDto> result = this.specService.getSpecsOfMember(memberId);
         return ResponseEntity.ok(
@@ -40,6 +193,99 @@ public class SpecController {
     }
 
     @PutMapping("/members/{memberId}/specs")
+    @Operation(
+            summary = "경력 및 수상 이력 수정",
+            parameters = @Parameter(
+                    description = "회원 ID",
+                    required = true,
+                    example = "10005"
+            ),
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = """
+                            SpecUpdateType에는 INSERT, UPDATE, DELETE가 있으며,
+                            INSERT는 새로운 Spec 추가, UPDATE는 기존 Spec 수정, DELETE는 기존 Spec 삭제다.
+                            1. INSERT의 경우 specId는 nullable이며 spec은 null이면 안 된다.
+                            2. UPDATE의 경우 specId와 spec은 null이면 안 된다.
+                            3. DELETE의 경우 spec은 nullable이며 specId는 null이면 안 된다.
+                            """,
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = SpecUpdateRequestDtoListSchema.class),
+                            examples = @ExampleObject("""
+                                    [
+                                        {
+                                            "specUpdateType": "INSERT",
+                                            "spec": {
+                                                "startDate": "2020-10-21",
+                                                "endDate": "2022-10-21",
+                                                "title": "새 스펙",
+                                                "description": "스펙",
+                                                "isCurrent": false
+                                            }
+                                        },
+                                        {
+                                            "specUpdateType": "UPDATE",
+                                            "specId": 100,
+                                            "spec": {
+                                                "startDate": "2020-10-21",
+                                                "endDate": "2022-10-21",
+                                                "title": "스포애니 전문 트레이너",
+                                                "description": "원래는 에이블짐 트레이너였음",
+                                                "isCurrent": false
+                                            }
+                                        },
+                                        {
+                                            "specUpdateType": "DELETE",
+                                            "specId": 101
+                                        }
+                                    ]
+                                    """)
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 업데이트 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = SpecUpdateResponseDtoSchema.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                                "statusCode": 200,
+                                                "statusCodeSeries": 2,
+                                                "content": {
+                                                    "insertedSpecIds": [
+                                                        99, 105
+                                                    ],
+                                                    "updatedSpecIds": [
+                                                        100
+                                                    ],
+                                                    "deletedSpecIds": [
+                                                        101
+                                                    ]
+                                                }
+                                            }
+                                            """,
+                                            description = "insertedSpecIds는 추가된 Spec의 ID, updatedSpecIds는 수정된 Spec의 ID, deletedSpecIds는 삭제된 스펙의 ID")
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "존재하지 않는 회원에 대한 경력 수정을 시도할 경우",
+                            content = @Content(
+                                    schema = @Schema(implementation = BasicErrorResponse.class),
+                                    examples = @ExampleObject("""
+                                            {
+                                                "errorCode": "SP001",
+                                                "statusCode": 40400,
+                                                "message": "해당 회원이 존재하지 않습니다",
+                                                "errorName": "MEMBER_NOT_FOUND",
+                                                "statusCodeSeries": 4
+                                            }
+                                            """)
+                            )
+                    )
+            }
+    )
     public ResponseEntity<ApiBasicResponse<SpecUpdateResponseDto>> updateSpecs(@PathVariable("memberId") Long memberId,
                                                                                @RequestBody @Valid List<SpecUpdateRequestDto> dto) {
         SpecUpdateResponseDto result = this.specService.updateSpecsOfMember(memberId, dto);

--- a/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/ListSpecDtoSchema.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/ListSpecDtoSchema.java
@@ -1,0 +1,8 @@
+package com.hf.healthfriend.domain.spec.controller.schema;
+
+import com.hf.healthfriend.domain.spec.dto.SpecDto;
+
+import java.util.ArrayList;
+
+public class ListSpecDtoSchema extends ArrayList<SpecDto> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/SpecUpdateRequestDtoListSchema.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/SpecUpdateRequestDtoListSchema.java
@@ -1,0 +1,8 @@
+package com.hf.healthfriend.domain.spec.controller.schema;
+
+import com.hf.healthfriend.domain.spec.dto.request.SpecUpdateRequestDto;
+
+import java.util.ArrayList;
+
+public class SpecUpdateRequestDtoListSchema extends ArrayList<SpecUpdateRequestDto> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/SpecUpdateResponseDtoSchema.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/controller/schema/SpecUpdateResponseDtoSchema.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.domain.spec.controller.schema;
+
+import com.hf.healthfriend.domain.spec.dto.response.SpecUpdateResponseDto;
+import com.hf.healthfriend.global.spec.ApiBasicResponse;
+
+public class SpecUpdateResponseDtoSchema extends ApiBasicResponse<SpecUpdateResponseDto> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/spec/exception/SpecErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/exception/SpecErrorCode.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public enum SpecErrorCode {
-    MEMBER_NOT_FOUND(40000, "SP001", "해당 회원이 존재하지 않습니다");
+    MEMBER_NOT_FOUND(40400, "SP001", "해당 회원이 존재하지 않습니다");
 
     private int status;
     private String code;

--- a/src/main/java/com/hf/healthfriend/domain/spec/exception/SpecExceptionHandlingControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/spec/exception/SpecExceptionHandlingControllerAdvice.java
@@ -22,7 +22,7 @@ public class SpecExceptionHandlingControllerAdvice {
                         .statusCode(MEMBER_NOT_FOUND.status())
                         .message(MEMBER_NOT_FOUND.message() + " - memberId=" + e.getMemberId())
                         .build(),
-                HttpStatus.BAD_REQUEST
+                HttpStatus.NOT_FOUND
         );
     }
 }

--- a/src/main/java/com/hf/healthfriend/global/spec/schema/LongTypeListSchema.java
+++ b/src/main/java/com/hf/healthfriend/global/spec/schema/LongTypeListSchema.java
@@ -1,0 +1,6 @@
+package com.hf.healthfriend.global.spec.schema;
+
+import java.util.ArrayList;
+
+public class LongTypeListSchema extends ArrayList<Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,9 @@ logging:
       hf:
         healthfriend: trace
 
+redis:
+  host: redis://localhost:6379
+
 management:
   endpoint:
     beans:

--- a/src/test/java/com/hf/healthfriend/domain/spec/controller/SpecControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/spec/controller/SpecControllerMockMvcTest.java
@@ -1,0 +1,382 @@
+package com.hf.healthfriend.domain.spec.controller;
+
+import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.domain.spec.constants.SpecUpdateType;
+import com.hf.healthfriend.domain.spec.dto.SpecDto;
+import com.hf.healthfriend.domain.spec.dto.request.SpecUpdateRequestDto;
+import com.hf.healthfriend.domain.spec.dto.response.SpecUpdateResponseDto;
+import com.hf.healthfriend.domain.spec.service.SpecService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SpecController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+@MockBean(MemberRepository.class)
+class SpecControllerMockMvcTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SpecService specService;
+
+    static class IsSpecDtoSame implements ArgumentMatcher<List<SpecDto>> {
+        List<SpecDto> specDtos;
+
+        IsSpecDtoSame(List<SpecDto> specDtos) {
+            this.specDtos = specDtos;
+        }
+
+        @Override
+        public boolean matches(List<SpecDto> argument) {
+            return this.specDtos.stream()
+                    .allMatch((specDto) ->
+                            argument.stream()
+                                    .anyMatch((arg) ->
+                                            isTwoObjectSame(arg.getSpecId(), specDto.getSpecId())
+                                                    && isTwoObjectSame(arg.getTitle(), specDto.getTitle())
+                                                    && isTwoObjectSame(arg.getDescription(), specDto.getDescription())
+                                                    && isTwoObjectSame(arg.getStartDate(), specDto.getStartDate())
+                                                    && isTwoObjectSame(arg.isCurrent(), specDto.isCurrent())
+                                                    && isTwoObjectSame(arg.getEndDate(), specDto.getEndDate())));
+        }
+    }
+
+    static class IsSpecUpdateRequestDtoSame implements ArgumentMatcher<List<SpecUpdateRequestDto>> {
+        List<SpecUpdateRequestDto> specUpdateRequestDtos;
+
+        IsSpecUpdateRequestDtoSame(List<SpecUpdateRequestDto> specUpdateRequestDtos) {
+            this.specUpdateRequestDtos = specUpdateRequestDtos;
+        }
+
+        @Override
+        public boolean matches(List<SpecUpdateRequestDto> argument) {
+            return this.specUpdateRequestDtos.stream()
+                    .allMatch((specDto) ->
+                            argument.stream()
+                                    .anyMatch((arg) ->
+                                            isTwoObjectSame(arg.getSpecId(), specDto.getSpecId())
+                                                    && isTwoObjectSame(arg.getSpecUpdateType(), specDto.getSpecUpdateType())
+                                                    && (
+                                                    arg.getSpec() == null && specDto.getSpec() == null
+                                                            || (arg.getSpec() != null && specDto.getSpec() != null
+                                                            && isTwoObjectSame(arg.getSpec().getTitle(), specDto.getSpec().getTitle())
+                                                            && isTwoObjectSame(arg.getSpec().getDescription(), specDto.getSpec().getDescription())
+                                                            && isTwoObjectSame(arg.getSpec().getStartDate(), specDto.getSpec().getStartDate())
+                                                            && isTwoObjectSame(arg.getSpec().isCurrent(), specDto.getSpec().isCurrent())
+                                                            && isTwoObjectSame(arg.getSpec().getEndDate(), specDto.getSpec().getEndDate()))
+
+                                            )
+                                    ));
+        }
+    }
+
+    private static boolean isTwoObjectSame(Object obj1, Object obj2) {
+        if (obj1 == null || obj2 == null) {
+            return obj1 == null && obj2 == null;
+        }
+        return obj1.equals(obj2);
+    }
+
+    @DisplayName("POST - /hf/members/{memberId}/specs - 경력 및 수상 이력 추가 성공")
+    @Test
+    void addSpecs() throws Exception {
+        // Given
+        List<SpecDto> given = List.of(
+                SpecDto.builder()
+                        .title("경력1")
+                        .startDate(LocalDate.of(2017, 11, 23))
+                        .endDate(LocalDate.of(2018, 11, 12))
+                        .isCurrent(false)
+                        .description("종료된 경력")
+                        .build(),
+                SpecDto.builder()
+                        .title("경력2")
+                        .startDate(LocalDate.of(2024, 8, 24))
+                        .isCurrent(true)
+                        .description("현재 진행 중인 경력")
+                        .build(),
+                SpecDto.builder()
+                        .title("수상1")
+                        .startDate(LocalDate.of(2020, 11, 23))
+                        .isCurrent(false)
+                        .description("")
+                        .build()
+        );
+        when(this.specService.addSpec(eq(1000L), argThat(new IsSpecDtoSame(given)))).thenReturn(List.of(100L, 101L, 102L));
+
+        // When
+        ResultActions result = this.mockMvc.perform(
+                post("/hf/members/{memberId}/specs", 1000L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                [
+                                    {
+                                        "startDate": "2017-11-23",
+                                        "endDate": "2018-11-12",
+                                        "isCurrent": false,
+                                        "title": "경력1",
+                                        "description": "종료된 경력"
+                                    },
+                                    {
+                                        "startDate": "2024-08-24",
+                                        "endDate": null,
+                                        "isCurrent": true,
+                                        "title": "경력2",
+                                        "description": "현재 진행 중인 경력"
+                                    },
+                                    {
+                                        "startDate": "2020-11-23",
+                                        "endDate": null,
+                                        "isCurrent": false,
+                                        "title": "수상1",
+                                        "description": ""
+                                    }
+                                ]
+                                """)
+        ).andDo(log()).andDo(print());
+
+        // Then
+        result.andExpect(status().isCreated())
+                .andExpect(content()
+                        .json("""
+                                {
+                                    "statusCode": 201,
+                                    "statusCodeSeries": 2,
+                                    "content": [
+                                        100,
+                                        101,
+                                        102
+                                    ]
+                                }
+                                """));
+    }
+
+    @DisplayName("POST - /hf/members/{memberId}/specs - 경력 및 수상 이력 추가 실패 - 404 - 없는 회원에 대한 정보 조회")
+    @Test
+    void addSpecs_fail() throws Exception {
+        // Given
+        List<SpecDto> given = List.of(
+                SpecDto.builder()
+                        .title("경력1")
+                        .startDate(LocalDate.of(2017, 11, 23))
+                        .endDate(LocalDate.of(2018, 11, 12))
+                        .isCurrent(false)
+                        .description("종료된 경력")
+                        .build(),
+                SpecDto.builder()
+                        .title("경력2")
+                        .startDate(LocalDate.of(2024, 8, 24))
+                        .isCurrent(true)
+                        .description("현재 진행 중인 경력")
+                        .build(),
+                SpecDto.builder()
+                        .title("수상1")
+                        .startDate(LocalDate.of(2020, 11, 23))
+                        .isCurrent(false)
+                        .description("")
+                        .build()
+        );
+        when(this.specService.addSpec(eq(1001L), argThat(new IsSpecDtoSame(given)))).thenThrow(new MemberNotFoundException(1001L));
+
+        // When
+        ResultActions result = this.mockMvc.perform(
+                post("/hf/members/{memberId}/specs", 1001L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                [
+                                    {
+                                        "startDate": "2017-11-23",
+                                        "endDate": "2018-11-12",
+                                        "isCurrent": false,
+                                        "title": "경력1",
+                                        "description": "종료된 경력"
+                                    },
+                                    {
+                                        "startDate": "2024-08-24",
+                                        "endDate": null,
+                                        "isCurrent": true,
+                                        "title": "경력2",
+                                        "description": "현재 진행 중인 경력"
+                                    },
+                                    {
+                                        "startDate": "2020-11-23",
+                                        "endDate": null,
+                                        "isCurrent": false,
+                                        "title": "수상1",
+                                        "description": ""
+                                    }
+                                ]
+                                """)
+        ).andDo(log()).andDo(print());
+
+        // Then
+        result.andExpect(status().isNotFound())
+                .andExpect(content()
+                        .json("""
+                                {
+                                    "errorCode": "SP001",
+                                    "statusCode": 40400,
+                                    "errorName": "MEMBER_NOT_FOUND",
+                                    "statusCodeSeries": 4
+                                }
+                                """));
+    }
+
+    @DisplayName("GET /hf/members/{memberId}/specs - 특정 회원이 가진 경력 및 수상 이력 조회 성공")
+    @Test
+    void getSpecsOfMember_success() throws Exception {
+        // Given
+        when(this.specService.getSpecsOfMember(1000L)).thenReturn(List.of(
+                SpecDto.builder()
+                        .specId(1000L)
+                        .title("스펙1")
+                        .startDate(LocalDate.of(2018, 3, 5))
+                        .endDate(LocalDate.of(2019, 5, 7))
+                        .isCurrent(false)
+                        .description("")
+                        .build()
+        ));
+
+        // When
+        ResultActions result = this.mockMvc.perform(get("/hf/members/{memberId}/specs", 1000L))
+                .andDo(print()).andDo(log());
+
+        // Then
+        result.andExpect(status().isOk())
+                .andExpect(content().json("""
+                        {
+                            "statusCode": 200,
+                            "statusCodeSeries": 2,
+                            "content": [
+                                {
+                                    "specId": 1000,
+                                    "title": "스펙1",
+                                    "startDate": "2018-03-05",
+                                    "endDate": "2019-05-07",
+                                    "isCurrent": false,
+                                    "description": ""
+                                }
+                            ]
+                        }
+                        """));
+    }
+
+    @DisplayName("PUT /hf/members/{memberId}/specs - 경력 및 수상 이력 수정 성공")
+    @Test
+    void updateSpecs_success() throws Exception {
+        // Given
+        List<SpecUpdateRequestDto> given = List.of(
+                SpecUpdateRequestDto.builder()
+                        .specUpdateType(SpecUpdateType.INSERT)
+                        .spec(
+                                SpecDto.builder()
+                                        .startDate(LocalDate.of(2020, 10, 21))
+                                        .endDate(LocalDate.of(2022, 10, 21))
+                                        .title("새 스펙")
+                                        .description("스펙")
+                                        .isCurrent(false)
+                                        .build()
+                        )
+                        .build(),
+                SpecUpdateRequestDto.builder()
+                        .specUpdateType(SpecUpdateType.UPDATE)
+                        .specId(100L)
+                        .spec(
+                                SpecDto.builder()
+                                        .startDate(LocalDate.of(2020, 10, 21))
+                                        .endDate(LocalDate.of(2022, 10, 21))
+                                        .title("스포애니 전문 트레이너")
+                                        .description("원래는 에이블짐 트레이너였음")
+                                        .isCurrent(false)
+                                        .build()
+                        )
+                        .build(),
+                SpecUpdateRequestDto.builder()
+                        .specUpdateType(SpecUpdateType.DELETE)
+                        .specId(101L)
+                        .build()
+        );
+
+        when(this.specService.updateSpecsOfMember(eq(10005L), argThat(new IsSpecUpdateRequestDtoSame(given))))
+                .thenReturn(new SpecUpdateResponseDto(List.of(99L), List.of(100L), List.of(101L)));
+
+        // When
+        ResultActions result = this.mockMvc.perform(
+                put("/hf/members/{memberId}/specs", 10005)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                [
+                                    {
+                                        "specUpdateType": "INSERT",
+                                        "spec": {
+                                            "startDate": "2020-10-21",
+                                            "endDate": "2022-10-21",
+                                            "title": "새 스펙",
+                                            "description": "스펙",
+                                            "isCurrent": false
+                                        }
+                                    },
+                                    {
+                                        "specUpdateType": "UPDATE",
+                                        "specId": 100,
+                                        "spec": {
+                                            "startDate": "2020-10-21",
+                                            "endDate": "2022-10-21",
+                                            "title": "스포애니 전문 트레이너",
+                                            "description": "원래는 에이블짐 트레이너였음",
+                                            "isCurrent": false
+                                        }
+                                    },
+                                    {
+                                        "specUpdateType": "DELETE",
+                                        "specId": 101
+                                    }
+                                ]
+                                """)
+        ).andDo(print()).andDo(log());
+
+        // Then
+        result.andExpect(status().isOk())
+                .andExpect(content().json("""
+                        {
+                            "statusCode": 200,
+                            "statusCodeSeries": 2,
+                            "content": {
+                                "insertedSpecIds": [
+                                    99
+                                ],
+                                "updatedSpecIds": [
+                                    100
+                                ],
+                                "deletedSpecIds": [
+                                    101
+                                ]
+                            }
+                        }
+                        """));
+    }
+}


### PR DESCRIPTION
# 이슈 번호
#83 

## 개요
경력 및 수상 이력 API 문서가 없어서 API 문서를 상세히 작성하였고, MockMvc 기반 경력 및 수상 이력 API 테스트 코드 작성