### PR TITLE
Feature/레벨 제도 구현

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/matching/entity/Matching.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/entity/Matching.java
@@ -90,6 +90,8 @@ public class Matching {
         }
         this.status = MatchingStatus.FINISHED;
         this.finishTime = LocalDateTime.now();
+        this.requester.incrementMatchedCount();
+        this.targetMember.incrementMatchedCount();
     }
 
     public int sizeOfReviews() {

--- a/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Objects;
+
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @ToString
@@ -30,5 +32,18 @@ public class Tier {
             tier++;
         }
         return new Tier(fitnessLevel, TIER_MILESTONE.length + 1);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Tier tier1 = (Tier) o;
+        return fitnessLevel == tier1.fitnessLevel && Objects.equals(tier, tier1.tier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fitnessLevel, tier);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
@@ -1,0 +1,34 @@
+package com.hf.healthfriend.domain.member.domain;
+
+import com.hf.healthfriend.domain.member.constant.FitnessLevel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+public class Tier {
+    private static final Long[] TIER_MILESTONE = {
+            5L, 9L, 14L, 20L
+    };
+
+    private final FitnessLevel fitnessLevel;
+    private final Integer tier;
+
+    public static Tier create(FitnessLevel fitnessLevel, Long matchedCount) {
+        if (fitnessLevel == FitnessLevel.ADVANCED) {
+            matchedCount -= TIER_MILESTONE[TIER_MILESTONE.length - 1];
+        }
+
+        int tier = 1;
+        for (Long milestone : TIER_MILESTONE) {
+            if (milestone > matchedCount) {
+                return new Tier(fitnessLevel, tier);
+            }
+            tier++;
+        }
+        return new Tier(fitnessLevel, TIER_MILESTONE.length + 1);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/domain/Tier.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 @ToString
 public class Tier {
     private static final Long[] TIER_MILESTONE = {
-            5L, 9L, 14L, 20L
+            5L, 10L, 15L, 20L
     };
 
     private final FitnessLevel fitnessLevel;

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.member.dto;
 
 import com.hf.healthfriend.domain.member.constant.*;
+import com.hf.healthfriend.domain.member.domain.Tier;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.spec.dto.SpecDto;
 import com.hf.healthfriend.global.util.mapping.BeanMapping;
@@ -43,5 +44,32 @@ public class MemberDto {
     private FitnessEagerness fitnessEagerness;
     private FitnessObjective fitnessObjective;
     private FitnessKind fitnessKind;
-    private List<SpecDto> specs;
+    private Long matchedCount;
+    private Tier tier;
+
+    public static MemberDto of(Member member) {
+        return MemberDto.builder()
+                .memberId(member.getId())
+                .loginId(member.getLoginId())
+                .role(member.getRole())
+                .name(member.getName())
+                .email(member.getEmail())
+                .creationTime(member.getCreationTime())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .cd1(member.getCd1())
+                .cd2(member.getCd2())
+                .cd3(member.getCd3())
+                .birthDate(member.getBirthDate())
+                .gender(member.getGender())
+                .introduction(member.getIntroduction())
+                .fitnessLevel(member.getFitnessLevel())
+                .companionStyle(member.getCompanionStyle())
+                .fitnessEagerness(member.getFitnessEagerness())
+                .fitnessObjective(member.getFitnessObjective())
+                .fitnessKind(member.getFitnessKind())
+                .matchedCount(member.getMatchedCount())
+                .tier(member.getTier())
+                .build();
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -180,4 +180,8 @@ public class Member implements UserDetails {
     public void delete() {
         this.isDeleted = true;
     }
+
+    public void incrementMatchedCount() {
+        this.matchedCount++;
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -137,7 +137,7 @@ public class Member implements UserDetails {
     private Double reviewScore = 0.0;
 
     @Column(name = "matched_count")
-    private Long matchedCount;
+    private Long matchedCount = 0L;
 
     public Member(long memberId) {
         this.id = memberId;

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.hf.healthfriend.domain.member.entity;
 import com.hf.healthfriend.domain.follow.entity.Follow;
 import com.hf.healthfriend.domain.matching.entity.Matching;
 import com.hf.healthfriend.domain.member.constant.*;
+import com.hf.healthfriend.domain.member.domain.Tier;
 import com.hf.healthfriend.domain.post.entity.Post;
 import com.hf.healthfriend.domain.review.entity.Review;
 import com.hf.healthfriend.domain.spec.entity.Spec;
@@ -183,5 +184,9 @@ public class Member implements UserDetails {
 
     public void incrementMatchedCount() {
         this.matchedCount++;
+    }
+
+    public Tier getTier() {
+        return Tier.create(this.fitnessLevel, this.matchedCount);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -89,7 +89,7 @@ public class MemberService {
     public MemberDto findMember(Long memberId) throws MemberNotFoundException {
         Member findMember = this.memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
-        return buildDto(findMember);
+        return MemberDto.of(findMember);
     }
 
     public MemberDto findMemberByLoginId(String loginId) throws MemberNotFoundException {
@@ -100,7 +100,7 @@ public class MemberService {
     public MemberDto findMemberByEmail(String email) throws MemberNotFoundException {
         Member findMember = this.memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(email));
-        return buildDto(findMember);
+        return MemberDto.of(findMember);
     }
 
     public MemberUpdateResponseDto updateMember(Long memberId, MemberUpdateRequestDto requestDto) throws MemberNotFoundException {
@@ -147,15 +147,6 @@ public class MemberService {
     public List<MemberRecommendResponse> recommendMember(MembersRecommendRequest request, int pageNumber){
         Pageable pageable = PageRequest.of(pageNumber - 1, 6);
         return memberRepository.recommendMembers(request, pageable);
-    }
-
-    private MemberDto buildDto(Member member) {
-        MemberDto memberDto = this.beanMapper.generateBean(member, MemberDto.class);
-        List<SpecDto> specsOfMember = this.specService.getSpecsOfMember(member.getId());
-        return memberDto.toBuilder()
-                .profileImageUrl(this.fileUrlResolver.resolveFileUrl(member.getProfileImageUrl()))
-                .specs(specsOfMember)
-                .build();
     }
 
     public List<MemberSearchResponse> searchMembers(String keyword, int pageNumber, int size){

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -1,14 +1,12 @@
 package com.hf.healthfriend.domain.member.service;
 
+import com.hf.healthfriend.domain.member.constant.FitnessLevel;
+import com.hf.healthfriend.domain.member.domain.Tier;
 import com.hf.healthfriend.domain.member.dto.MemberDto;
 import com.hf.healthfriend.domain.member.dto.request.MemberCreationRequestDto;
 import com.hf.healthfriend.domain.member.dto.request.MemberUpdateRequestDto;
 import com.hf.healthfriend.domain.member.dto.request.MembersRecommendRequest;
-import com.hf.healthfriend.domain.member.dto.response.MemberCreationResponseDto;
-import com.hf.healthfriend.domain.member.dto.response.MemberRecommendResponse;
-import com.hf.healthfriend.domain.member.dto.response.MemberSearchResponse;
-import com.hf.healthfriend.domain.member.dto.response.MemberUpdateResponseDto;
-import com.hf.healthfriend.domain.member.dto.response.ProfileResponseDto;
+import com.hf.healthfriend.domain.member.dto.response.*;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.exception.DuplicateMemberCreationException;
 import com.hf.healthfriend.domain.member.exception.FitnessLevelUpdateException;
@@ -19,7 +17,6 @@ import com.hf.healthfriend.domain.member.repository.dto.ProfileQueryResultDto;
 import com.hf.healthfriend.domain.review.dto.response.RevieweeResponseDto;
 import com.hf.healthfriend.domain.review.dto.response.SimpleReviewResponseDto;
 import com.hf.healthfriend.domain.review.service.ReviewService;
-import com.hf.healthfriend.domain.spec.dto.SpecDto;
 import com.hf.healthfriend.domain.spec.service.SpecService;
 import com.hf.healthfriend.global.file.FileUrlResolver;
 import com.hf.healthfriend.global.util.mapping.BeanMapper;
@@ -135,12 +132,15 @@ public class MemberService {
         if (requestDto.getFitnessLevel() == null) {
             return;
         }
-        switch (requestDto.getFitnessLevel()) {
-            case ADVANCED -> {
-                // TODO: 매칭 횟수 10번 미만일 경우 validation 에러
+
+        if (requestDto.getFitnessLevel() == FitnessLevel.ADVANCED) {
+            Member member = this.memberRepository.findById(memberId)
+                    .orElseThrow(() -> new MemberNotFoundException(memberId));
+            Tier tier = member.getTier();
+            if (tier.getFitnessLevel() != FitnessLevel.BEGINNER
+                    || tier.getTier() == 5) {
+                throw new FitnessLevelUpdateException("새싹에서 고수로 변경할 때 새싹 레벨 5여야 합니다.");
             }
-            case BEGINNER ->
-                throw new FitnessLevelUpdateException("고수에서 새싹으로 변경 불가");
         }
     }
 
@@ -149,7 +149,7 @@ public class MemberService {
         return memberRepository.recommendMembers(request, pageable);
     }
 
-    public List<MemberSearchResponse> searchMembers(String keyword, int pageNumber, int size){
+    public List<MemberSearchResponse> searchMembers(String keyword, int pageNumber, int size) {
         Pageable pageable = PageRequest.of(pageNumber - 1, size);
         return memberRepository.searchMembers(keyword, pageable);
     }

--- a/src/test/java/com/hf/healthfriend/domain/member/domain/TierTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/domain/TierTest.java
@@ -12,10 +12,10 @@ class TierTest {
     @DisplayName("Tier.create")
     @CsvSource(value = {
             "BEGINNER,0,1", "BEGINNER,1,1", "BEGINNER,4,1", "BEGINNER,5,2",
-            "BEGINNER,6,2", "BEGINNER,9,3", "BEGINNER,13,3", "BEGINNER,14,4",
+            "BEGINNER,6,2", "BEGINNER,10,3", "BEGINNER,13,3", "BEGINNER,15,4",
             "BEGINNER,19,4", "BEGINNER,20,5", "BEGINNER,21,5", "BEGINNER,29,5",
-            "ADVANCED,20,1", "ADVANCED,20,1", "ADVANCED,24,1", "ADVANCED,25,2",
-            "ADVANCED,29,3", "ADVANCED,34,4", "ADVANCED,39,4", "ADVANCED,40,5",
+            "ADVANCED,20,1", "ADVANCED,21,1", "ADVANCED,24,1", "ADVANCED,25,2",
+            "ADVANCED,30,3", "ADVANCED,35,4", "ADVANCED,39,4", "ADVANCED,40,5",
             "ADVANCED,41,5", "ADVANCED,45,5,", "ADVANCED,1354153,5"
     }, delimiter = ',')
     @ParameterizedTest

--- a/src/test/java/com/hf/healthfriend/domain/member/domain/TierTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/domain/TierTest.java
@@ -1,0 +1,28 @@
+package com.hf.healthfriend.domain.member.domain;
+
+import com.hf.healthfriend.domain.member.constant.FitnessLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TierTest {
+
+    @DisplayName("Tier.create")
+    @CsvSource(value = {
+            "BEGINNER,0,1", "BEGINNER,1,1", "BEGINNER,4,1", "BEGINNER,5,2",
+            "BEGINNER,6,2", "BEGINNER,9,3", "BEGINNER,13,3", "BEGINNER,14,4",
+            "BEGINNER,19,4", "BEGINNER,20,5", "BEGINNER,21,5", "BEGINNER,29,5",
+            "ADVANCED,20,1", "ADVANCED,20,1", "ADVANCED,24,1", "ADVANCED,25,2",
+            "ADVANCED,29,3", "ADVANCED,34,4", "ADVANCED,39,4", "ADVANCED,40,5",
+            "ADVANCED,41,5", "ADVANCED,45,5,", "ADVANCED,1354153,5"
+    }, delimiter = ',')
+    @ParameterizedTest
+    void create_success(FitnessLevel fitnessLevel, Long matchedCount, Integer expectedTier) {
+        Tier result = Tier.create(fitnessLevel, matchedCount);
+
+        assertThat(result.getFitnessLevel()).isEqualTo(fitnessLevel);
+        assertThat(result.getTier()).isEqualTo(expectedTier);
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/repository/TestMemberRepository.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.member.repository;
 
+import com.hf.healthfriend.domain.member.constant.Gender;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.dto.ProfileQueryResultDto;
 import com.hf.healthfriend.domain.spec.dto.SpecDto;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalDate;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 

--- a/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/service/TestMemberService.java
@@ -401,21 +401,6 @@ class TestMemberService {
         return Character.toLowerCase(getterName.charAt(0)) + getterName.substring(1);
     }
 
-    @DisplayName("updateMember - 운동 레벨을 \"고수\"에서 \"새싹\"으로 바꿀 경우 예외 발생 - FitnessLevelUpdateException")
-    @Test
-    void updateMember_updateFitnessLevelNotAllowed_FitnessLevelUpdateException() {
-        Member sampleMember = SampleEntityGenerator.generateSampleMember("sample@gmail.com");
-        sampleMember.setFitnessLevel(FitnessLevel.ADVANCED);
-        this.memberRepository.save(sampleMember);
-
-        MemberUpdateRequestDto updateDto = MemberUpdateRequestDto.builder()
-                .fitnessLevel(FitnessLevel.BEGINNER)
-                .build();
-
-        assertThatExceptionOfType(FitnessLevelUpdateException.class)
-                .isThrownBy(() -> this.memberService.updateMember(sampleMember.getId(), updateDto));
-    }
-
     @DisplayName("updateMember - 없는 회원일 경우 MemberNotFoundException 발생")
     @Test
     void updateMember_MemberNotFoundException() {


### PR DESCRIPTION
# 이슈 번호
#105 

## 개요
- 매칭 카운트에 따라 레벨을 산정하는 기능 구현
- 새싹에서 고수로 변경할 때, 새싹 레벨 5여야 고수로 변경할 수 있도록 수정
- 운동 스타일은 옵션값으로 설정

## 추가사항
PR #110의 내용을 포함하고 있습니다.