### PR TITLE
Feature/쿠폰 도메인의 세부적인 기능 구현

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/controller/CouponController.java
@@ -66,4 +66,20 @@ public class CouponController {
                 ApiBasicResponse.of(result, HttpStatus.OK)
         );
     }
+
+    @PatchMapping("/coupons/{couponId}/read")
+    @Operation(
+            summary = "쿠폰을 읽는다.",
+            description = "쿠폰을 읽으면 쿠폰의 \"NEW\" 표시가 사라짐",
+            responses = @ApiResponse(
+                    description = "쿠폰 읽기 성공",
+                    responseCode = "200"
+            )
+    )
+    public ResponseEntity<ApiBasicResponse<Void>> readCoupon(@PathVariable("couponId") Long couponId) {
+        this.couponService.readCoupon(couponId);
+        return ResponseEntity.ok(
+                ApiBasicResponse.of(HttpStatus.OK)
+        );
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
@@ -32,7 +32,10 @@ public abstract class Coupon {
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime creationTime = LocalDateTime.now();
 
+    @Column(name = "is_used")
     private boolean used = false;
+
+    @Column(name = "is_read")
     private boolean read = false;
 
     protected Coupon(Member receiver, LocalDateTime expiration) {

--- a/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.coupon.entity;
 
+import com.hf.healthfriend.domain.coupon.constant.CouponType;
 import com.hf.healthfriend.domain.coupon.exception.AlreadyUsedCouponException;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -74,4 +75,6 @@ public abstract class Coupon {
     public boolean isNotAvailable() {
         return isUsed() || isExpired();
     }
+
+    public abstract CouponType getCouponType();
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/entity/Coupon.java
@@ -7,7 +7,6 @@ import lombok.*;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
@@ -70,5 +69,9 @@ public abstract class Coupon {
     public long getValidPeriod(TemporalUnit temporalUnit) {
         return Duration.between(this.creationTime, this.expiration)
                 .get(temporalUnit);
+    }
+
+    public boolean isNotAvailable() {
+        return isUsed() || isExpired();
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/entity/MatchingCoupon.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/entity/MatchingCoupon.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.coupon.entity;
 
+import com.hf.healthfriend.domain.coupon.constant.CouponType;
 import com.hf.healthfriend.domain.coupon.exception.InvalidMatchingCountException;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
@@ -45,5 +46,10 @@ public class MatchingCoupon extends Coupon {
         if (--this.leftMatchingCount == 0) {
             super.use();
         }
+    }
+
+    @Override
+    public CouponType getCouponType() {
+        return CouponType.MATCHING_COUPON;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/exception/CouponNotFoundException.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/exception/CouponNotFoundException.java
@@ -1,0 +1,29 @@
+package com.hf.healthfriend.domain.coupon.exception;
+
+import lombok.Getter;
+
+import java.util.NoSuchElementException;
+
+@Getter
+public class CouponNotFoundException extends NoSuchElementException {
+    private final Long couponId;
+
+    public CouponNotFoundException(Long couponId) {
+        this.couponId = couponId;
+    }
+
+    public CouponNotFoundException(String s, Throwable cause, Long couponId) {
+        super(s, cause);
+        this.couponId = couponId;
+    }
+
+    public CouponNotFoundException(Throwable cause, Long couponId) {
+        super(cause);
+        this.couponId = couponId;
+    }
+
+    public CouponNotFoundException(String s, Long couponId) {
+        super(s);
+        this.couponId = couponId;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/coupon/exception/UnavailableCouponException.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/exception/UnavailableCouponException.java
@@ -1,0 +1,27 @@
+package com.hf.healthfriend.domain.coupon.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UnavailableCouponException extends RuntimeException {
+    private final Long couponId;
+
+    public UnavailableCouponException(Long couponId) {
+        this.couponId = couponId;
+    }
+
+    public UnavailableCouponException(String message, Long couponId) {
+        super(message);
+        this.couponId = couponId;
+    }
+
+    public UnavailableCouponException(String message, Throwable cause, Long couponId) {
+        super(message, cause);
+        this.couponId = couponId;
+    }
+
+    public UnavailableCouponException(Throwable cause, Long couponId) {
+        super(cause);
+        this.couponId = couponId;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/repository/CouponRepository.java
@@ -3,6 +3,13 @@ package com.hf.healthfriend.domain.coupon.repository;
 import com.hf.healthfriend.domain.coupon.entity.Coupon;
 import com.hf.healthfriend.domain.coupon.repository.querydsl.CouponCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long>, CouponCustomRepository {
+
+    @Modifying
+    @Query(value = "UPDATE coupon SET is_read = TRUE WHERE coupon_id = :couponId", nativeQuery = true)
+    void setReadById(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.coupon.service;
 
 import com.hf.healthfriend.domain.coupon.constant.CouponFetchType;
+import com.hf.healthfriend.domain.coupon.constant.CouponType;
 import com.hf.healthfriend.domain.coupon.dto.request.GrantCouponDto;
 import com.hf.healthfriend.domain.coupon.dto.response.CouponResponseDto;
 import com.hf.healthfriend.domain.coupon.entity.Coupon;
@@ -50,13 +51,15 @@ public class CouponService {
      * 쿠폰을 사용한다.
      *
      * @param couponId 사용할 쿠폰의 ID
+     * @param couponType 사용할 쿠폰의 타입
      * @throws UnavailableCouponException 기간이 만료되었거나 이미 사용한 쿠폰인 경우와 같이 사용할 수 없는 쿠폰일 경우
      * @throws CouponNotFoundException couponId에 해당하는 쿠폰이 존재하지 않을 경우
      */
-    public void useCoupon(Long couponId) throws UnavailableCouponException, CouponNotFoundException {
+    public void useCoupon(Long couponId, CouponType couponType)
+            throws UnavailableCouponException, CouponNotFoundException {
         Coupon coupon = this.couponRepository.findById(couponId)
                 .orElseThrow(() -> new CouponNotFoundException(couponId));
-        if (coupon.isNotAvailable()) {
+        if (coupon.isNotAvailable() || coupon.getCouponType() != couponType) {
             throw new UnavailableCouponException(couponId);
         }
 

--- a/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
@@ -40,4 +40,8 @@ public class CouponService {
                 .map(this.couponDtoMapper::mapToCouponResponseDto)
                 .toList();
     }
+
+    public void readCoupon(Long couponId) {
+        this.couponRepository.setReadById(couponId);
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
@@ -5,6 +5,7 @@ import com.hf.healthfriend.domain.coupon.dto.request.GrantCouponDto;
 import com.hf.healthfriend.domain.coupon.dto.response.CouponResponseDto;
 import com.hf.healthfriend.domain.coupon.entity.Coupon;
 import com.hf.healthfriend.domain.coupon.exception.NoSupportedCouponDelegatorException;
+import com.hf.healthfriend.domain.coupon.exception.UnavailableCouponException;
 import com.hf.healthfriend.domain.coupon.repository.CouponRepository;
 import com.hf.healthfriend.domain.coupon.util.CouponDtoMapper;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +45,22 @@ public class CouponService {
 
     public void readCoupon(Long couponId) {
         this.couponRepository.setReadById(couponId);
+    }
+
+    /**
+     * 쿠폰을 사용한다.
+     *
+     * @param couponId 사용할 쿠폰의 ID
+     * @throws UnavailableCouponException 기간이 만료되었거나 이미 사용한 쿠폰인 경우와 같이 사용할 수 없는 쿠폰일 경우
+     * @throws NoSuchElementException couponId에 해당하는 쿠폰이 존재하지 않을 경우
+     */
+    public void useCoupon(Long couponId) throws UnavailableCouponException, NoSuchElementException {
+        Coupon coupon = this.couponRepository.findById(couponId)
+                .orElseThrow(NoSuchElementException::new);
+        if (coupon.isNotAvailable()) {
+            throw new UnavailableCouponException(couponId);
+        }
+
+        coupon.use();
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/hf/healthfriend/domain/coupon/service/CouponService.java
@@ -4,7 +4,7 @@ import com.hf.healthfriend.domain.coupon.constant.CouponFetchType;
 import com.hf.healthfriend.domain.coupon.dto.request.GrantCouponDto;
 import com.hf.healthfriend.domain.coupon.dto.response.CouponResponseDto;
 import com.hf.healthfriend.domain.coupon.entity.Coupon;
-import com.hf.healthfriend.domain.coupon.exception.NoSupportedCouponDelegatorException;
+import com.hf.healthfriend.domain.coupon.exception.CouponNotFoundException;
 import com.hf.healthfriend.domain.coupon.exception.UnavailableCouponException;
 import com.hf.healthfriend.domain.coupon.repository.CouponRepository;
 import com.hf.healthfriend.domain.coupon.util.CouponDtoMapper;
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -52,11 +51,11 @@ public class CouponService {
      *
      * @param couponId 사용할 쿠폰의 ID
      * @throws UnavailableCouponException 기간이 만료되었거나 이미 사용한 쿠폰인 경우와 같이 사용할 수 없는 쿠폰일 경우
-     * @throws NoSuchElementException couponId에 해당하는 쿠폰이 존재하지 않을 경우
+     * @throws CouponNotFoundException couponId에 해당하는 쿠폰이 존재하지 않을 경우
      */
-    public void useCoupon(Long couponId) throws UnavailableCouponException, NoSuchElementException {
+    public void useCoupon(Long couponId) throws UnavailableCouponException, CouponNotFoundException {
         Coupon coupon = this.couponRepository.findById(couponId)
-                .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(() -> new CouponNotFoundException(couponId));
         if (coupon.isNotAvailable()) {
             throw new UnavailableCouponException(couponId);
         }

--- a/src/main/java/com/hf/healthfriend/domain/matching/constant/MatchingStatus.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/constant/MatchingStatus.java
@@ -2,6 +2,7 @@ package com.hf.healthfriend.domain.matching.constant;
 
 public enum MatchingStatus {
     PENDING,
+    CANCELED,
     ACCEPTED,
     REJECTED,
     UNEXPECTEDLY_HALTED,

--- a/src/main/java/com/hf/healthfriend/domain/matching/dto/request/MatchingRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/dto/request/MatchingRequestDto.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.matching.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -19,6 +20,9 @@ public class MatchingRequestDto {
     
     @NotNull
     private Long targetId;
+
+    @Schema(description = "null일 경우 쿠폰을 사용하지 않음. null이 아닐 경우 쿠폰을 사용해 매칭하는 것")
+    private Long couponId;
 
     @NotNull
     @NotEmpty

--- a/src/main/java/com/hf/healthfriend/domain/matching/entity/Matching.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/entity/Matching.java
@@ -22,11 +22,11 @@ public class Matching {
     @Column(name = "matching_id")
     private Long matchingId;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "requester_id")
     private Member requester;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "request_target_id")
     private Member targetMember;
 

--- a/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingErrorCode.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MatchingErrorCode {
     MEMBER_NOT_FOUND(40401, "MAT001", "해당 회원이 존재하지 않습니다"),
-    OUT_OF_LIMIT_MATCHING_REQUEST(40001, "MAT002", "중복된 매칭이 있습니다");
+    OUT_OF_LIMIT_MATCHING_REQUEST(40001, "MAT002", "중복된 매칭이 있습니다"),
+    INVALID_COUPON_USAGE(40002, "MAT003", "사용할 수 없는 쿠폰입니다"),
+    COUPON_NOT_FOUND(40402, "MAT004", "쿠폰이 존재하지 않습니다");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingErrorCode.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingErrorCode.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MatchingErrorCode {
-    MEMBER_NOT_FOUND(40401, "MAT001", "해당 회원이 존재하지 않습니다");
+    MEMBER_NOT_FOUND(40401, "MAT001", "해당 회원이 존재하지 않습니다"),
+    OUT_OF_LIMIT_MATCHING_REQUEST(40001, "MAT002", "중복된 매칭이 있습니다");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingExceptionHandlingControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingExceptionHandlingControllerAdvice.java
@@ -13,14 +13,26 @@ public class MatchingExceptionHandlingControllerAdvice {
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<BasicErrorResponse> memberNotFoundException(MemberNotFoundException e) {
         return new ResponseEntity<>(
-                BasicErrorResponse.builder()
-                        .statusCode(MatchingErrorCode.MEMBER_NOT_FOUND.status())
-                        .errorName(MatchingErrorCode.MEMBER_NOT_FOUND.name())
-                        .message(MatchingErrorCode.MEMBER_NOT_FOUND.message())
-                        .statusCodeSeries(4)
-                        .errorCode(MatchingErrorCode.MEMBER_NOT_FOUND.code())
-                        .build(),
+                from(MatchingErrorCode.MEMBER_NOT_FOUND),
                 HttpStatus.NOT_FOUND
         );
+    }
+
+    @ExceptionHandler(OutOfLimitMatchingRequestException.class)
+    public ResponseEntity<BasicErrorResponse> outOfLimitMatchingRequestException(OutOfLimitMatchingRequestException e) {
+        return new ResponseEntity<>(
+                from(MatchingErrorCode.OUT_OF_LIMIT_MATCHING_REQUEST),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    private BasicErrorResponse from(MatchingErrorCode errorCode) {
+        return BasicErrorResponse.builder()
+                .statusCode(errorCode.status())
+                .errorName(errorCode.name())
+                .message(errorCode.message())
+                .statusCodeSeries(4)
+                .errorCode(errorCode.code())
+                .build();
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingExceptionHandlingControllerAdvice.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/exception/MatchingExceptionHandlingControllerAdvice.java
@@ -1,38 +1,53 @@
 package com.hf.healthfriend.domain.matching.exception;
 
+import com.hf.healthfriend.domain.coupon.exception.CouponNotFoundException;
+import com.hf.healthfriend.domain.coupon.exception.UnavailableCouponException;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import com.hf.healthfriend.global.spec.BasicErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static com.hf.healthfriend.domain.matching.exception.MatchingErrorCode.*;
+
+@Slf4j
 @RestControllerAdvice(basePackages = "com.hf.healthfriend.domain.matching")
 public class MatchingExceptionHandlingControllerAdvice {
 
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<BasicErrorResponse> memberNotFoundException(MemberNotFoundException e) {
-        return new ResponseEntity<>(
-                from(MatchingErrorCode.MEMBER_NOT_FOUND),
-                HttpStatus.NOT_FOUND
-        );
+        return from(MEMBER_NOT_FOUND, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(OutOfLimitMatchingRequestException.class)
     public ResponseEntity<BasicErrorResponse> outOfLimitMatchingRequestException(OutOfLimitMatchingRequestException e) {
-        return new ResponseEntity<>(
-                from(MatchingErrorCode.OUT_OF_LIMIT_MATCHING_REQUEST),
-                HttpStatus.BAD_REQUEST
-        );
+        return from(OUT_OF_LIMIT_MATCHING_REQUEST, HttpStatus.BAD_REQUEST);
     }
 
-    private BasicErrorResponse from(MatchingErrorCode errorCode) {
-        return BasicErrorResponse.builder()
-                .statusCode(errorCode.status())
-                .errorName(errorCode.name())
-                .message(errorCode.message())
-                .statusCodeSeries(4)
-                .errorCode(errorCode.code())
-                .build();
+    @ExceptionHandler(CouponNotFoundException.class)
+    public ResponseEntity<BasicErrorResponse> couponNotFoundException(CouponNotFoundException e) {
+        log.info("존재하지 않는 쿠폰 사용 - couponId={}", e.getCouponId());
+        return from(COUPON_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(UnavailableCouponException.class)
+    public ResponseEntity<BasicErrorResponse> unavailableCouponException(UnavailableCouponException e) {
+        log.info("유효하지 않은 쿠폰 사용 - couponId={}", e.getCouponId());
+        return from(INVALID_COUPON_USAGE, HttpStatus.BAD_REQUEST);
+    }
+
+    private ResponseEntity<BasicErrorResponse> from(MatchingErrorCode errorCode, HttpStatus status) {
+        return new ResponseEntity<>(
+                BasicErrorResponse.builder()
+                        .statusCode(errorCode.status())
+                        .errorName(errorCode.name())
+                        .message(errorCode.message())
+                        .statusCodeSeries(4)
+                        .errorCode(errorCode.code())
+                        .build(),
+                status
+        );
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/matching/exception/OutOfLimitMatchingRequestException.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/exception/OutOfLimitMatchingRequestException.java
@@ -1,0 +1,16 @@
+package com.hf.healthfriend.domain.matching.exception;
+
+public class OutOfLimitMatchingRequestException extends RuntimeException {
+
+    public OutOfLimitMatchingRequestException(String message) {
+        super(message);
+    }
+
+    public OutOfLimitMatchingRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OutOfLimitMatchingRequestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/matching/repository/querydsl/MatchingCustomRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/repository/querydsl/MatchingCustomRepository.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+
 public interface MatchingCustomRepository {
 
 
@@ -14,4 +16,17 @@ public interface MatchingCustomRepository {
                                                                @NotNull MatchingFetchType matchingFetchType,
                                                                @NotNull MatchingStatusCondition matchingStatusCondition,
                                                                @NotNull Pageable page);
+
+    /**
+     * <p>중복되는 매칭이 있는지 체크하는 메소드.
+     * <p>매칭 중복 여부:
+     *
+     * <p>1. 주어진 날짜에 신청된 매칭이 있는 경우 중복
+     * <p>2. 해당 회원이 이미 진행 중인 매칭이 있는 경우 중복
+     *
+     * @param memberId 체크하려는 회원의 ID
+     * @param date 체크하려는 날짜
+     * @return 중복이 있으면 true, 그렇지 않으면 false를 반환
+     */
+    boolean existsDuplicateMatchingRequest(Long memberId, LocalDate date);
 }

--- a/src/main/java/com/hf/healthfriend/domain/matching/repository/querydsl/MatchingCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/repository/querydsl/MatchingCustomRepositoryImpl.java
@@ -1,13 +1,17 @@
 package com.hf.healthfriend.domain.matching.repository.querydsl;
 
 import com.hf.healthfriend.domain.matching.constant.MatchingFetchType;
+import com.hf.healthfriend.domain.matching.constant.MatchingStatus;
 import com.hf.healthfriend.domain.matching.constant.MatchingStatusCondition;
 import com.hf.healthfriend.domain.matching.dto.response.MatchingListResponseDto;
 import com.hf.healthfriend.domain.matching.dto.response.ProfileOfMemberInMatchingResponseDto;
 import com.hf.healthfriend.domain.matching.entity.QMatching;
 import com.hf.healthfriend.domain.member.entity.QMember;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +21,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -99,5 +105,23 @@ public class MatchingCustomRepositoryImpl implements MatchingCustomRepository {
             builder.and(this.matching.status.in(matchingStatus.getCorrespondingStatus()));
         }
         return builder;
+    }
+
+    @Override
+    public boolean existsDuplicateMatchingRequest(Long memberId, LocalDate date) {
+        BooleanExpression compareDatePart =
+                Expressions.dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, this.matching.creationTime)
+                        .eq(date);
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder(compareDatePart);
+
+        booleanBuilder.or(this.matching.status.in(MatchingStatus.ACCEPTED, MatchingStatus.PENDING));
+        booleanBuilder.and(this.matching.requester.id.eq(memberId));
+
+        Integer result = this.queryFactory.selectOne()
+                .from(this.matching)
+                .where(booleanBuilder)
+                .fetchFirst();
+        return result != null;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.matching.service;
 
+import com.hf.healthfriend.domain.coupon.service.CouponService;
 import com.hf.healthfriend.domain.matching.constant.MatchingFetchType;
 import com.hf.healthfriend.domain.matching.constant.MatchingStatus;
 import com.hf.healthfriend.domain.matching.constant.MatchingStatusCondition;
@@ -45,9 +46,15 @@ public class MatchingService {
 
     private final MatchingRepository matchingRepository;
     private final MemberRepository memberRepository;
+    private final CouponService couponService;
 
     public Long requestMatching(MatchingRequestDto requestDto) {
-        if (this.matchingRepository.existsDuplicateMatchingRequest(requestDto.getRequesterId(), LocalDate.now())) {
+        boolean couponUsed = false;
+        if (requestDto.getCouponId() != null) {
+            this.couponService.useCoupon(requestDto.getCouponId());
+            couponUsed = true;
+        }
+        if (!couponUsed && this.matchingRepository.existsDuplicateMatchingRequest(requestDto.getRequesterId(), LocalDate.now())) {
             throw new OutOfLimitMatchingRequestException("매칭 중복");
         }
         try {

--- a/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.matching.service;
 
+import com.hf.healthfriend.domain.coupon.constant.CouponType;
 import com.hf.healthfriend.domain.coupon.service.CouponService;
 import com.hf.healthfriend.domain.matching.constant.MatchingFetchType;
 import com.hf.healthfriend.domain.matching.constant.MatchingStatus;
@@ -51,7 +52,7 @@ public class MatchingService {
     public Long requestMatching(MatchingRequestDto requestDto) {
         boolean couponUsed = false;
         if (requestDto.getCouponId() != null) {
-            this.couponService.useCoupon(requestDto.getCouponId());
+            this.couponService.useCoupon(requestDto.getCouponId(), CouponType.MATCHING_COUPON);
             couponUsed = true;
         }
         if (!couponUsed && this.matchingRepository.existsDuplicateMatchingRequest(requestDto.getRequesterId(), LocalDate.now())) {

--- a/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
+++ b/src/main/java/com/hf/healthfriend/domain/matching/service/MatchingService.java
@@ -8,6 +8,7 @@ import com.hf.healthfriend.domain.matching.dto.request.MatchingRequestDto;
 import com.hf.healthfriend.domain.matching.dto.response.MatchingListResponseDto;
 import com.hf.healthfriend.domain.matching.dto.response.PageResponseDto;
 import com.hf.healthfriend.domain.matching.entity.Matching;
+import com.hf.healthfriend.domain.matching.exception.OutOfLimitMatchingRequestException;
 import com.hf.healthfriend.domain.matching.repository.MatchingRepository;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -45,6 +47,9 @@ public class MatchingService {
     private final MemberRepository memberRepository;
 
     public Long requestMatching(MatchingRequestDto requestDto) {
+        if (this.matchingRepository.existsDuplicateMatchingRequest(requestDto.getRequesterId(), LocalDate.now())) {
+            throw new OutOfLimitMatchingRequestException("매칭 중복");
+        }
         try {
             Matching savedMatching = this.matchingRepository.save(
                     new Matching(

--- a/src/test/java/com/hf/healthfriend/domain/matching/repository/querydsl/TestMatchingCustomRepositoryImpl.java
+++ b/src/test/java/com/hf/healthfriend/domain/matching/repository/querydsl/TestMatchingCustomRepositoryImpl.java
@@ -10,11 +10,12 @@ import com.hf.healthfriend.testutil.SampleEntityGenerator;
 import com.hf.healthfriend.testutil.TestConfig;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -22,8 +23,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Stream;
@@ -42,25 +45,8 @@ class TestMatchingCustomRepositoryImpl {
     @Autowired
     EntityManager em;
 
-    Member mainMember;
-    Map<String, Member> dummyMembersByKey;
-    List<Matching> dummyMatchings;
-
     static final int REQUESTER_NUM = 7;
     static final int REQUEST_TARGET_NUM = 7;
-
-    @BeforeEach
-    void initialData() throws NoSuchFieldException, IllegalAccessException {
-        Member mainMember = SampleEntityGenerator.generateSampleMember("main@gmail.com", "main");
-        this.em.persist(mainMember);
-
-        Map<String, Member> dummyMembers = generateDummyMembers();
-        List<Matching> matchings = generateMatchings(mainMember, dummyMembers);
-
-        this.mainMember = mainMember;
-        this.dummyMembersByKey = dummyMembers;
-        this.dummyMatchings = matchings;
-    }
 
     private Map<String, Member> generateDummyMembers() {
         Map<String, Member> dummyMembers = new HashMap<>();
@@ -210,15 +196,21 @@ class TestMatchingCustomRepositoryImpl {
     void findByMemberIdWithConditions_success(String parameterizedName,
                                               MatchingFetchType fetchType,
                                               MatchingStatusCondition condition,
-                                              Pageable page) {
+                                              Pageable page) throws NoSuchFieldException, IllegalAccessException {
         // Given
-        List<Matching> filteredMatchings = filterBySearchCondtition(this.dummyMatchings, fetchType, condition);
+        Member mainMember = SampleEntityGenerator.generateSampleMember("main@gmail.com", "main");
+        this.em.persist(mainMember);
+
+        Map<String, Member> dummyMembersByKey = generateDummyMembers();
+        List<Matching> dummyMatchings = generateMatchings(mainMember, dummyMembersByKey);
+
+        List<Matching> filteredMatchings = filterBySearchCondtition(dummyMatchings, fetchType, condition, mainMember);
         List<Matching> expectedMatchingList =
                 subListWithoutOverflow(filteredMatchings, (int) page.getOffset(), (int) page.getOffset() + page.getPageSize());
 
         // When
         Page<MatchingListResponseDto> result =
-                this.matchingCustomRepository.findByMemberIdWithConditions(this.mainMember.getId(), fetchType, condition, page);
+                this.matchingCustomRepository.findByMemberIdWithConditions(mainMember.getId(), fetchType, condition, page);
 
         // Then
         log.info("expected matching ids={}", expectedMatchingList.stream().map(Matching::getMatchingId).toList());
@@ -231,11 +223,12 @@ class TestMatchingCustomRepositoryImpl {
 
     private List<Matching> filterBySearchCondtition(List<Matching> original,
                                                     MatchingFetchType fetchType,
-                                                    MatchingStatusCondition condition) {
+                                                    MatchingStatusCondition condition,
+                                                    Member mainMember) {
         return original.stream()
                 .filter((m) -> fetchType == MatchingFetchType.ALL
-                        || (fetchType == MatchingFetchType.WHAT_I_RECEIVED && m.getTargetMember().getId().equals(this.mainMember.getId()))
-                        || (fetchType == MatchingFetchType.WHAT_I_REQUESTED && m.getRequester().getId().equals(this.mainMember.getId())))
+                        || (fetchType == MatchingFetchType.WHAT_I_RECEIVED && m.getTargetMember().getId().equals(mainMember.getId()))
+                        || (fetchType == MatchingFetchType.WHAT_I_REQUESTED && m.getRequester().getId().equals(mainMember.getId())))
                 .filter((m) -> condition == MatchingStatusCondition.ALL
                         || condition.getCorrespondingStatus().contains(m.getStatus()))
                 .toList();
@@ -246,5 +239,82 @@ class TestMatchingCustomRepositoryImpl {
             return List.of();
         }
         return original.subList(fromIndex, Math.min(endIndex, original.size()));
+    }
+
+    @DisplayName("existsDuplicateMatchingRequest - 해당 날짜에 생성된 Matching이 존재할 경우 true")
+    @Test
+    void existsDuplicateMatchingRequest() {
+        // Given
+        Member mainMember = SampleEntityGenerator.generateSampleMember("main@gmail.com", "main");
+        this.em.persist(mainMember);
+
+        Map<String, Member> dummyMembersByKey = generateDummyMembers();
+
+        Member dummyTargetMember = dummyMembersByKey.get("ee" + (REQUESTER_NUM + 1));
+        Matching dummyMatching =
+                new Matching(mainMember, dummyTargetMember, "a", "b", LocalDateTime.now().plusDays(1));
+        this.em.persist(dummyMatching);
+        this.em.flush();
+
+        // When
+        boolean result =
+                this.matchingCustomRepository.existsDuplicateMatchingRequest(mainMember.getId(), LocalDate.now());
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("existsDuplicateMatchingRequest - 중복 허용인 status라도 해당 날짜에 생성된 매칭이면 true")
+    @ValueSource(strings = {
+            "CANCELED",
+            "REJECTED",
+            "UNEXPECTEDLY_HALTED",
+            "FINISHED"
+    })
+    @ParameterizedTest
+    void existsDuplicateMatchingRequest_matchingStatus_false(MatchingStatus matchingStatus) {
+        // Given
+        Member mainMember = SampleEntityGenerator.generateSampleMember("main@gmail.com", "main");
+        this.em.persist(mainMember);
+
+        Map<String, Member> dummyMembersByKey = generateDummyMembers();
+
+        Member dummyTargetMember = dummyMembersByKey.get("ee" + (REQUESTER_NUM + 1));
+        Matching dummyMatching =
+                new Matching(mainMember, dummyTargetMember, "a", "b", LocalDateTime.now().plusDays(1));
+        ReflectionTestUtils.setField(dummyMatching, "status", matchingStatus);
+        this.em.persist(dummyMatching);
+
+        // When
+        boolean result = this.matchingCustomRepository.existsDuplicateMatchingRequest(mainMember.getId(), LocalDate.now());
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("existsDuplicateMatchingRequest - 다른 날짜에 생성되었더라도 진행 중이 매칭이면 true")
+    @ValueSource(
+            strings = {
+                    "ACCEPTED",
+                    "PENDING"
+            }
+    )
+    @ParameterizedTest
+    void existsDuplicateMatchingRequest_generatedAnotherDate(MatchingStatus matchingStatus) {
+        // Given
+        Member mainMember = SampleEntityGenerator.generateSampleMember("main@gmail.com", "main");
+        this.em.persist(mainMember);
+
+        Map<String, Member> dummyMembersByKey = generateDummyMembers();
+
+        Member dummyTargetMember = dummyMembersByKey.get("ee" + (REQUESTER_NUM + 1));
+        Matching dummyMatching =
+                new Matching(mainMember, dummyTargetMember, "a", "b", LocalDateTime.now().plusDays(1));
+        ReflectionTestUtils.setField(dummyMatching, "status", matchingStatus);
+        ReflectionTestUtils.setField(dummyMatching, "creationTime", LocalDateTime.now().minusDays(3));
+        this.em.persist(dummyMatching);
+
+        // When
+        this.matchingCustomRepository.existsDuplicateMatchingRequest(mainMember.getId(), LocalDate.now());
     }
 }


### PR DESCRIPTION
# 이슈 번호
#113 

# 개요
쿠폰 도메인의 세부적인 기능 구현
- 쿠폰 읽기 (쿠폰 목록에서 "N" 떠 있는 거 쿠폰 읽으면 없앨 수 있음)
- 매칭 쿠폰 사용
- 유효하지 않은 쿠폰 사용 시 예외 발생 로직 구현

# 추가사항
- PR #116의 커밋을 포함하고 있습니다.
- 이 PR에서의 변경사항을 리뷰하는 데 집중할 수 있도록 base 브랜치를 PR #116의 브랜치인 Feature/coupon-presentation-layer#113 브랜치로 설정했습니다.
- develop 브랜치에 반영된 사항을 pull했습니다.