### PR TITLE
fix: 경력 및 수상 이력 선택 항목으로 변경

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberCreationRequestDto.java
@@ -81,6 +81,5 @@ public class MemberCreationRequestDto {
     private FitnessKind fitnessKind;
 
     @Schema(description = "수상 및 경력")
-    @NotNull
     private List<SpecDto> specs;
 }


### PR DESCRIPTION
# 이슈 번호
#121

## 개요
회원 등록 시 경력 및 수상 이력이 필수값으로 되어 있는데 이를 선택값으로 변경 (기존에는 빈 배열을 넘기는 것으로 처리했음)