### PR TITLE
fix: CORS 허용 메소드 중에 PATCH 추가

### DIFF
--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -122,7 +122,7 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(Collections.singletonList(this.clientOrigin));
-        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         config.setAllowCredentials(true);
         config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept", "Cookie"));
         config.setExposedHeaders(Arrays.asList("Authorization"));


### PR DESCRIPTION
# 개요
CORS 메소드 중에 PATCH 메소드가 없어서 PATCH 요청에 대해 CORS 에러가 발생함