### PR TITLE
Feature: GET /posts/{postId}/likes 엔드포인트 명세 변경

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/like/controller/LikeController.java
+++ b/src/main/java/com/hf/healthfriend/domain/like/controller/LikeController.java
@@ -10,6 +10,7 @@ import com.hf.healthfriend.global.spec.BasicErrorResponse;
 import com.hf.healthfriend.global.spec.schema.LongTypeSchema;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -54,19 +55,37 @@ public class LikeController {
 
     @GetMapping(value = "/posts/{postId}/likes", params = "memberId")
     @Operation(
-            summary = "회원이 해당 글에 좋아요를 남겼는지 여부 조회",
+            summary = "특정 post에 특정 회원이 남긴 좋아요의 ID 조회",
             responses = {
                     @ApiResponse(
-                            description = "좋아요 여부 조회 성공",
+                            description = "좋아요 여부 조회 성공. 만약 회원이 post에 좋아요를 남기지 않았다면 content는 null",
                             responseCode = "200",
-                            content = @Content(schema = @Schema(implementation = LikeDtoSchema.class))
+                            content = @Content(
+                                    schema = @Schema(implementation = LongTypeSchema.class),
+                                    examples = {
+                                            @ExampleObject("""
+                                                    {
+                                                        "statusCode": 200,
+                                                        "statusCodeSeries": 2,
+                                                        "content": 2000
+                                                    }
+                                                    """),
+                                            @ExampleObject("""
+                                                    {
+                                                        "statusCode": 200,
+                                                        "statusCodeSeries: 2,
+                                                        "content": null
+                                                    }
+                                                    """)
+                                    }
+                            )
                     )
             }
     )
-    public ResponseEntity<ApiBasicResponse<Boolean>> doesMemberLikeThePost(@PathVariable("postId") Long postId,
+    public ResponseEntity<ApiBasicResponse<Long>> doesMemberLikeThePost(@PathVariable("postId") Long postId,
                                                                    @RequestParam("memberId") Long memberId) {
         return new ResponseEntity<>(
-                ApiBasicResponse.of(this.likeService.doesMemberLikePost(memberId, postId), HttpStatus.OK),
+                ApiBasicResponse.of(this.likeService.getLikeIdOfMemberToPost(memberId, postId), HttpStatus.OK),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/hf/healthfriend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/like/repository/LikeRepository.java
@@ -24,6 +24,16 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             FROM Like l
             WHERE l.post.postId = :postId
                 AND l.member.id = :memberId
+                AND l.canceled = FALSE
+            """)
+    Optional<Like> findByMemberIdAndPostId(@Param("memberId") Long memberId,
+                                                            @Param("postId") Long postId);
+
+    @Query("""
+            SELECT l
+            FROM Like l
+            WHERE l.post.postId = :postId
+                AND l.member.id = :memberId
             """)
     Optional<Like> findByMemberIdAndPostIdIncludingCanceled(@Param("memberId") Long memberId,
                                                             @Param("postId") Long postId);

--- a/src/main/java/com/hf/healthfriend/domain/like/service/LikeService.java
+++ b/src/main/java/com/hf/healthfriend/domain/like/service/LikeService.java
@@ -126,14 +126,15 @@ public class LikeService {
     }
 
     /**
-     * 특정 회원이 특정 글에 좋아요를 남겼는지 확인
+     * 특정 회원이 특정 글에 남긴 좋아요 ID를 반환
      *
      * @param memberId 좋아요를 남겼는지 체크할 회원의 ID
      * @param postId 회원이 좋아요를 남겼는지 체크할 Post의 ID
-     * @return 해당 회원이 해당 글에 좋아요를 남겼으면 true, 그렇지 않으면 false
+     * @return member가 post에 남긴 좋아요의 ID를 반환. 만약 주어진 member가 주어진 post에 좋아요를 남기지 않았을 경우, null 반환
      */
-    public boolean doesMemberLikePost(Long memberId, Long postId) {
-        return this.likeRepository.existsByMemberIdAndPostId(memberId, postId);
+    public Long getLikeIdOfMemberToPost(Long memberId, Long postId) {
+        return this.likeRepository.findByMemberIdAndPostId(memberId, postId)
+                .orElse(new Like(null)).getLikeId();
     }
 
     public List<PostLikeDto> getLikeOfPost(Long postId) {

--- a/src/test/java/com/hf/healthfriend/domain/like/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/like/repository/LikeRepositoryTest.java
@@ -180,4 +180,17 @@ class LikeRepositoryTest {
         boolean result = this.likeRepository.existsByPostAndMember(post, member);
         assertThat(result).isFalse();
     }
+
+    @DisplayName("existsByMemberIdAndPostId - for canceled like")
+    @Test
+    void existsByMemberIdAndPostId_forCanceledLike() {
+        // Given
+        this.likeMember1_Post1.cancel();
+
+        // When
+        boolean result = this.likeRepository.existsByMemberIdAndPostId(this.member1.getId(), this.savedPost1.getPostId());
+
+        // Then
+        assertThat(result).isFalse();
+    }
 }


### PR DESCRIPTION
# 개요
/posts/{postId}/likes 엔드포인트에서 해당 회원이 해당 post에 좋아요를 눌렀는지 여부를 boolean으로 반환하는 대신 likeId를 반환하는 게 더 좋겠다는 프론트엔드 팀원분의 의견을 받아 해당 엔드포인트 기능 변경