### PR TITLE
Fix/LikeService.cancelLike NPE 발생

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/like/repository/LikeRepository.java
@@ -91,5 +91,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     void deleteLikeByPostId(@Param("postId") Long postId);
 
     @Query("SELECT l.post.postId FROM Like l WHERE l.likeId=:likeId ")
-    Long findPostIdByLikeId(@Param("likeId") Long likeId);
+    Optional<Long> findPostIdByLikeId(@Param("likeId") Long likeId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/like/service/LikeService.java
+++ b/src/main/java/com/hf/healthfriend/domain/like/service/LikeService.java
@@ -165,7 +165,8 @@ public class LikeService {
         likeEntity.cancel();
         postRepository.decrementLikeCountByLikeId(likeIdToCancel);
 
-        long postId = likeRepository.findPostIdByLikeId(likeIdToCancel);
+        long postId = likeRepository.findPostIdByLikeId(likeIdToCancel)
+                .orElseThrow(NoSuchElementException::new);
         // TODO 동시성 처리 필요
         deletePopularPost(postId);
 


### PR DESCRIPTION
# 개요
`LikeService.cancelLike()` 메소드 내부의
```
long postId = likeRepository.findPostIdByLikeId(likeIdToCancel);
```
이 부분에서 findPostIdByLikeId가 null일 경우 NPE가 발생함. 그래서 `LikeRepository.findPostIdByLikeId()` 메소드의 리턴 타입을 Optional로 설정함으로써 null 체크함
