### PR TITLE
Fix/ 글 목록 댓글수 수정

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/accesscontrol/CommentAccessController.java
@@ -4,8 +4,12 @@ import com.hf.healthfriend.auth.accesscontrol.AccessControlTrigger;
 import com.hf.healthfriend.auth.accesscontrol.AccessController;
 import com.hf.healthfriend.domain.comment.entity.Comment;
 import com.hf.healthfriend.domain.comment.exception.CommentErrorCode;
+import com.hf.healthfriend.domain.comment.exception.CommentException;
+import com.hf.healthfriend.domain.comment.repository.CommentJpaRepository;
 import com.hf.healthfriend.domain.comment.repository.CommentRepository;
 import com.hf.healthfriend.domain.member.constant.Role;
+import com.hf.healthfriend.domain.post.exception.PostErrorCode;
+import com.hf.healthfriend.domain.post.exception.PostException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +22,7 @@ import java.util.Optional;
 @AccessController
 @RequiredArgsConstructor
 public class CommentAccessController {
-    private final CommentRepository commentRepository;
+    private final CommentJpaRepository commentJpaRepository;
 
     @AccessControlTrigger(path = "/hf/comments/{commentId}", method = "DELETE")
     public boolean accessControlForCreatingComment(BearerTokenAuthentication authentication, HttpServletRequest request) {
@@ -33,26 +37,17 @@ public class CommentAccessController {
     }
 
     private boolean controlAccessToCommentResourceByCommentId(BearerTokenAuthentication authentication, HttpServletRequest request, CommentErrorCode errorCode) {
-        // TODO: AccessControlFilter에서 글로벌하게 처리해야 한다 (혹은 AOP)
-        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).anyMatch((g) -> Role.ROLE_ADMIN.name().equals(g))) {
-            return true;
-        }
-
+        Long memberId = Long.parseLong(authentication.getName());
         String path = request.getRequestURI();
-        long commentIdBeingAccessed = Long.parseLong(path.substring(path.lastIndexOf('/') + 1));
+        Long commentId = Long.parseLong(path.substring(path.lastIndexOf('/') + 1));
 
-        Optional<Comment> commentOp = this.commentRepository.findById(commentIdBeingAccessed);
-        if (commentOp.isEmpty()) {
-            return true; // 그대로 진행시켜서 404 Not Found가 나도록
-        }
-
-        if (log.isTraceEnabled()) {
-            log.trace("authentication={}", authentication);
-            log.trace("authentication.principal={}", authentication.getPrincipal());
-            log.trace("authentication.name={}", authentication.getName());
-        }
-
-        Comment comment = commentOp.get();
-        return comment.getWriter().getId().equals(Long.parseLong(authentication.getName()));
+        return commentJpaRepository.findByCommentIdAndIsDeletedFalse(commentId)
+                .map(comment -> {
+                    if (!comment.getWriter().getId().equals(memberId)) {
+                        throw new CommentException(errorCode);
+                    }
+                    return true;
+                })
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -14,11 +14,7 @@ import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import com.hf.healthfriend.domain.post.entity.Post;
-import com.hf.healthfriend.domain.post.exception.PostErrorCode;
-import com.hf.healthfriend.domain.post.exception.PostException;
 import com.hf.healthfriend.domain.post.repository.PostRepository;
-import com.hf.healthfriend.global.exception.CustomException;
-import com.hf.healthfriend.global.exception.ErrorCode;
 import com.hf.healthfriend.global.file.FileUrlResolver;
 import java.util.ArrayList;
 import java.util.Map;
@@ -67,6 +63,7 @@ public class CommentService {
                 .build();
 
         Comment newComment = this.commentRepository.save(toSave);
+        postRepository.incrementCommentsCount(postId);
         log.info("[Comment Creation] postId={}, commenterId={}", postId, requestDto.getWriterId());
 
         return CommentCreationResponseDto.builder()
@@ -79,7 +76,6 @@ public class CommentService {
                 .build();
     }
 
-    // TODO : 재귀 삭제
     public void deleteComment(Long commentId) throws CommentException {
         if(!commentJpaRepository.existsByCommentIdAndIsDeletedFalse(commentId)) {
             throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND, HttpStatus.NOT_FOUND,
@@ -89,6 +85,7 @@ public class CommentService {
         commentJpaRepository.deleteAllReplies(commentId);
         // 부모 댓글 soft delete
         commentJpaRepository.softDeleteById(commentId);
+        postRepository.decrementCommentsCountByCommentId(commentId);
     }
 
     public List<CommentDto> getCommentsOfPost(Long postId, CommentSortType sortType) {

--- a/src/main/java/com/hf/healthfriend/domain/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/dto/response/PostGetResponse.java
@@ -21,7 +21,7 @@ public record PostGetResponse(
         Long viewCount,
         Long likeCount,
         List<CommentDto> comments,
-        Integer commentCount
+        Long commentCount
 ) {
     public static PostGetResponse of(Post post, List<CommentDto> comments, String imagePath) {
         return PostGetResponse.builder()
@@ -37,7 +37,7 @@ public record PostGetResponse(
                 .viewCount(post.getViewCount())
                 .likeCount(post.getLikesCount())
                 .comments(comments)
-                .commentCount(comments.size())
+                .commentCount(post.getCommentsCount())
                 .build();
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/post/entity/Post.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/entity/Post.java
@@ -58,6 +58,9 @@ public class Post extends BaseTimeEntity {
     @Builder.Default
     private Long likesCount = 0L;
 
+    @Builder.Default
+    private Long commentsCount = 0L;
+
     private String imagePath;
 
     public Post(Long postId){

--- a/src/main/java/com/hf/healthfriend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/repository/PostRepository.java
@@ -16,13 +16,21 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
 
     Page<Post> findAll(Pageable pageable);
 
-    // 불필요한 필드 로드를 줄이려면 네이티브 쿼리를 적절히 사용할줄 알아야 함
     @Modifying
-    @Query(value = "UPDATE post SET likes_count = likes_count + 1 WHERE post_id = :postId", nativeQuery = true)
+    @Query("UPDATE Post p SET p.likesCount = p.likesCount + 1 WHERE p.postId = :postId")
     void incrementLikeCount(@Param("postId") Long postId);
 
     @Modifying
-    @Query(value = "UPDATE post p SET p.likes_count = p.likes_count - 1 " +
-            "WHERE p.post_id = (SELECT l.post_id FROM likes l WHERE l.like_id = :likeId)", nativeQuery = true)
+    @Query("UPDATE Post p SET p.likesCount = p.likesCount - 1 WHERE p.postId = " +
+            "(SELECT l.post.postId FROM Like l WHERE l.likeId = :likeId)")
     void decrementLikeCountByLikeId(@Param("likeId") Long likeId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.commentsCount = p.commentsCount + 1 WHERE p.postId = :postId")
+    void incrementCommentsCount(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.commentsCount = p.commentsCount - 1 WHERE p.postId = " +
+            "(SELECT c.post.postId FROM Comment c WHERE c.commentId = :commentId)")
+    void decrementCommentsCountByCommentId(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/post/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/repository/querydsl/PostCustomRepositoryImpl.java
@@ -51,6 +51,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                             .content(content)
                             .fitnessLevel(post.getMember().getFitnessLevel().name())
                             .likeCount(post.getLikesCount())
+                            .commentCount(post.getCommentsCount())
                             .totalPageSize(getTotalPageSize())
                             .memberProfileUrl(fileUrlResolver.resolveFileUrl(post.getMember().getProfileImageUrl()))
                             .build();
@@ -90,6 +91,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                             .content(content)
                             .fitnessLevel(post.getMember().getFitnessLevel().name())
                             .likeCount(post.getLikesCount())
+                            .commentCount(post.getCommentsCount())
                             .totalPageSize(totalPageSize)
                             .memberProfileUrl(fileUrlResolver.resolveFileUrl(post.getMember().getProfileImageUrl()))
                             .build();


### PR DESCRIPTION
# 이슈 번호 
# 개요 
- Post 엔티티에 commentsCount 추가했습니다.
  - 기존에는 post 객체를 가져와 post.comments.size()로 계산했는데 이러면 삭제된 댓글까지 합산됩니다.
  - 따라서 필드를 추가하고 댓글 생성/삭제 메서드에 incrementCommentsCount와 decrementCommentsCountByCommentId를 호출하는 방식으로 로직 변경했습니다.
  - 풀 받으시면 데이터베이스 다시 create 하셔야됩니다 (안 그럼 commentsCount 필드가 null이 떠서 500 에러 뜹니다.)
- comments patch/delete 403 에러 수정했습니다.
