### PR TITLE
Feature/채팅 엔티티 정의 및 채팅 신청 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/chat/constant/MatchingResponseType.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/constant/MatchingResponseType.java
@@ -1,0 +1,6 @@
+package com.hf.healthfriend.domain.chat.constant;
+
+public enum MatchingResponseType {
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/ChatParticipationRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/ChatParticipationRequestDto.java
@@ -1,0 +1,25 @@
+package com.hf.healthfriend.domain.chat.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class ChatParticipationRequestDto {
+
+    @Schema(description = "채팅 신청을 거는 회원 ID")
+    @NotNull
+    @Min(1)
+    private Long requesterId;
+
+    @Schema(description = "채팅 신청 받는 회원 ID")
+    @NotNull
+    @Min(1)
+    private Long chatTargetId;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/response/ChatParticipationResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/response/ChatParticipationResponseDto.java
@@ -1,0 +1,13 @@
+package com.hf.healthfriend.domain.chat.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ChatParticipationResponseDto(
+        Long newChatroomId,
+        List<Long> participantIds,
+        Long creatorId
+) {
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
@@ -1,0 +1,51 @@
+package com.hf.healthfriend.domain.chat.entity;
+
+import com.hf.healthfriend.domain.BaseTimeEntity;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import com.hf.healthfriend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatParticipation extends BaseTimeEntity {
+
+    @EmbeddedId
+    private ChatParticipationId chatParticipationId;
+
+    @MapsId("chatroomId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+
+    @MapsId("memberId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "is_notification_active")
+    private boolean notificationActive = true;
+
+    @Column(name = "is_discononected")
+    private boolean disconnected = false;
+
+    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    public ChatParticipation(ChatParticipationId id) {
+        this.chatParticipationId = id;
+    }
+
+    public ChatParticipation(Chatroom chatroom, Member member) {
+        this.chatroom = chatroom;
+        this.member = member;
+        this.chatroom.addChatParticipation(this);
+        this.member.addChatParticipation(this);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
@@ -1,15 +1,11 @@
 package com.hf.healthfriend.domain.chat.entity;
 
 import com.hf.healthfriend.domain.BaseTimeEntity;
-import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,6 +36,7 @@ public class ChatParticipation extends BaseTimeEntity {
     }
 
     public ChatParticipation(Chatroom chatroom, Member member) {
+        this(new ChatParticipationId(chatroom.getChatroomId(), member.getId()));
         this.chatroom = chatroom;
         this.member = member;
         this.chatroom.addChatParticipation(this);

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
@@ -35,9 +35,6 @@ public class ChatParticipation extends BaseTimeEntity {
     @Column(name = "is_discononected")
     private boolean disconnected = false;
 
-    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<ChatMessage> messages = new ArrayList<>();
-
     public ChatParticipation(ChatParticipationId id) {
         this.chatParticipationId = id;
     }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipationId.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipationId.java
@@ -1,0 +1,23 @@
+package com.hf.healthfriend.domain.chat.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * <p>하나의 Chatroom에 대한 한 명의 Member의 참여는 오직 하나만 존재하기 때문에
+ * ChatParticipation의 PK를 복합키로 설정. 이를 통해 ChatParticipation의 중복 삽입을 체크하는 로직 없이
+ * 중복 삽입 방지
+ */
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ChatParticipationId implements Serializable {
+    private Long chatroomId;
+    private Long memberId;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipationId.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipationId.java
@@ -1,10 +1,7 @@
 package com.hf.healthfriend.domain.chat.entity;
 
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
@@ -17,6 +14,7 @@ import java.io.Serializable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EqualsAndHashCode
+@Getter
 public class ChatParticipationId implements Serializable {
     private Long chatroomId;
     private Long memberId;

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
@@ -1,8 +1,8 @@
 package com.hf.healthfriend.domain.chat.entity;
 
 import com.hf.healthfriend.domain.BaseTimeEntity;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Getter
 public class Chatroom extends BaseTimeEntity {
 
@@ -21,13 +21,20 @@ public class Chatroom extends BaseTimeEntity {
     @Column(name = "is_deleted")
     private boolean deleted = false;
 
-    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipation> participations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
 
     private Long lastChatMessageId;
 
     public Chatroom(Long chatroomId) {
         this.chatroomId = chatroomId;
+    }
+
+    public Chatroom(List<ChatParticipation> chatParticipations) {
+        this.participations = chatParticipations;
     }
 
     public void addChatParticipation(ChatParticipation chatParticipation) {

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
@@ -1,0 +1,36 @@
+package com.hf.healthfriend.domain.chat.entity;
+
+import com.hf.healthfriend.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Chatroom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatroomId;
+
+    @Column(name = "is_deleted")
+    private boolean deleted = false;
+
+    @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatParticipation> participations = new ArrayList<>();
+
+    private Long lastChatMessageId;
+
+    public Chatroom(Long chatroomId) {
+        this.chatroomId = chatroomId;
+    }
+
+    public void addChatParticipation(ChatParticipation chatParticipation) {
+        this.participations.add(chatParticipation);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
@@ -1,0 +1,62 @@
+package com.hf.healthfriend.domain.chat.entity.chatmessage;
+
+import com.hf.healthfriend.domain.BaseTimeEntity;
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 하나의 외래키만으로 Member, Chatroom 두 엔티티에 접근할 수 있으므로 ChatParticipation에 매핑
+@Entity
+@Inheritance
+@DiscriminatorColumn(name = "message_type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class ChatMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatMessageId;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "chat_participation_id")
+    private ChatParticipation chatParticipation;
+
+    // 서비스에 일대일 채팅만 있으므로 ChatMessage 엔티티에서 채팅 읽었는지 여부 체크
+    // 나중에 기능이 확장될 경우, 크게 어려움 없이 기능 확장할 수 있을 듯
+    private boolean readByOpponent = false;
+
+    protected ChatMessage(Long chatMessageId) {
+        this.chatMessageId = chatMessageId;
+    }
+
+    protected ChatMessage(ChatParticipation chatParticipation) {
+        this.chatParticipation = chatParticipation;
+    }
+
+    /**
+     * 이 채팅 메시지를 읽었는지 여부 설정. 메시지 발행자와 메시지를 읽는 회원이 일치하면 채팅 메시지를 읽음 여부에 변화가 없고,
+     * 일치하지 않는다면 채팅 메시지 읽음 여부를 true로 변경.
+     *
+     * @param readerId 채팅을 읽는 회원의 ID
+     */
+    public void readIfOpponent(Long readerId) {
+        // Eager Fetch에 의해 ChatParticipation 엔티티는 이미 가지고 있음
+        // 그리고 회원의 ID만 조회하는 것이기 때문에 Member 엔티티에 대한 추가 쿼리는 날아가지 않음
+        if (this.chatParticipation.getMember().getId().equals(readerId)) {
+            this.readByOpponent = true;
+        }
+    }
+
+    /**
+     * 이 채팅 메시지를 읽었는지 여부 설정. 메시지 발행자와 메시지를 읽는 회원이 일치하면 채팅 메시지를 읽음 여부에 변화가 없고,
+     * 일치하지 않는다면 채팅 메시지 읽음 여부를 true로 변경.
+     *
+     * @param reader 채팅을 읽는 회원 엔티티
+     */
+    public void readIfOpponent(Member reader) {
+        readIfOpponent(reader.getId());
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
@@ -2,6 +2,7 @@ package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
 import com.hf.healthfriend.domain.BaseTimeEntity;
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -20,9 +21,13 @@ public abstract class ChatMessage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long chatMessageId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "chat_participation_id")
-    private ChatParticipation chatParticipation;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private Chatroom chatroom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     // 서비스에 일대일 채팅만 있으므로 ChatMessage 엔티티에서 채팅 읽었는지 여부 체크
     // 나중에 기능이 확장될 경우, 크게 어려움 없이 기능 확장할 수 있을 듯
@@ -32,8 +37,9 @@ public abstract class ChatMessage extends BaseTimeEntity {
         this.chatMessageId = chatMessageId;
     }
 
-    protected ChatMessage(ChatParticipation chatParticipation) {
-        this.chatParticipation = chatParticipation;
+    protected ChatMessage(Chatroom chatroom, Member sender) {
+        this.chatroom = chatroom;
+        this.member = sender;
     }
 
     /**
@@ -43,9 +49,8 @@ public abstract class ChatMessage extends BaseTimeEntity {
      * @param readerId 채팅을 읽는 회원의 ID
      */
     public void readIfOpponent(Long readerId) {
-        // Eager Fetch에 의해 ChatParticipation 엔티티는 이미 가지고 있음
-        // 그리고 회원의 ID만 조회하는 것이기 때문에 Member 엔티티에 대한 추가 쿼리는 날아가지 않음
-        if (this.chatParticipation.getMember().getId().equals(readerId)) {
+        // ID만 조회하는 것이기 때문에 추가 쿼리는 날아가지 않음
+        if (this.member.getId().equals(readerId)) {
             this.readByOpponent = true;
         }
     }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ImageChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ImageChatMessage.java
@@ -1,6 +1,8 @@
 package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -18,8 +20,8 @@ public class ImageChatMessage extends ChatMessage {
         super(chatMessageId);
     }
 
-    public ImageChatMessage(ChatParticipation chatParticipation, String imageUrl) {
-        super(chatParticipation);
+    public ImageChatMessage(Chatroom chatroom, Member sender, String imageUrl) {
+        super(chatroom, sender);
         this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ImageChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ImageChatMessage.java
@@ -1,0 +1,25 @@
+package com.hf.healthfriend.domain.chat.entity.chatmessage;
+
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("IMAGE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ImageChatMessage extends ChatMessage {
+    private String imageUrl;
+
+    public ImageChatMessage(Long chatMessageId) {
+        super(chatMessageId);
+    }
+
+    public ImageChatMessage(ChatParticipation chatParticipation, String imageUrl) {
+        super(chatParticipation);
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
@@ -1,6 +1,8 @@
 package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -19,8 +21,8 @@ public class MatchingRequestChatMessage extends ChatMessage {
         super(chatMessageId);
     }
 
-    public MatchingRequestChatMessage(ChatParticipation chatParticipation, LocalDateTime meetingDate, String place) {
-        super(chatParticipation);
+    public MatchingRequestChatMessage(Chatroom chatroom, Member sender, LocalDateTime meetingDate, String place) {
+        super(chatroom, sender);
         this.meetingDate = meetingDate;
         this.place = place;
     }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
@@ -1,0 +1,27 @@
+package com.hf.healthfriend.domain.chat.entity.chatmessage;
+
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@DiscriminatorValue("MAT_REQ")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingRequestChatMessage extends ChatMessage {
+    private LocalDateTime meetingDate;
+    private String place;
+
+    public MatchingRequestChatMessage(Long chatMessageId) {
+        super(chatMessageId);
+    }
+
+    public MatchingRequestChatMessage(ChatParticipation chatParticipation, LocalDateTime meetingDate, String place) {
+        super(chatParticipation);
+        this.meetingDate = meetingDate;
+        this.place = place;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingResponseChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingResponseChatMessage.java
@@ -1,0 +1,46 @@
+package com.hf.healthfriend.domain.chat.entity.chatmessage;
+
+import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("MAT_RESP")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MatchingResponseChatMessage extends ChatMessage {
+    private MatchingResponseType matchingResponseType;
+    private String cancelMessage; // 매칭 수락일 경우 null
+
+    public MatchingResponseChatMessage(Long chatMessageId) {
+        super(chatMessageId);
+    }
+
+    public MatchingResponseChatMessage(ChatParticipation chatParticipation,
+                                       MatchingResponseType matchingResponseType) {
+        super(chatParticipation);
+        this.matchingResponseType = matchingResponseType;
+    }
+
+    public MatchingResponseChatMessage(ChatParticipation chatParticipation,
+                                       MatchingResponseType matchingResponseType,
+                                       String cancelMessage) {
+        this(chatParticipation, matchingResponseType);
+        this.cancelMessage = cancelMessage;
+    }
+
+    public static MatchingResponseChatMessage createAcceptanceMessage(ChatParticipation chatParticipation) {
+        return new MatchingResponseChatMessage(chatParticipation, MatchingResponseType.ACCEPTED);
+    }
+
+    public static MatchingResponseChatMessage createRejectMessage(ChatParticipation chatParticipation,
+                                                                  String cancelMessage) {
+        return new MatchingResponseChatMessage(chatParticipation,
+                MatchingResponseType.REJECTED,
+                cancelMessage);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingResponseChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingResponseChatMessage.java
@@ -2,6 +2,8 @@ package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
 import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -20,26 +22,30 @@ public class MatchingResponseChatMessage extends ChatMessage {
         super(chatMessageId);
     }
 
-    public MatchingResponseChatMessage(ChatParticipation chatParticipation,
+    public MatchingResponseChatMessage(Chatroom chatroom,
+                                       Member sender,
                                        MatchingResponseType matchingResponseType) {
-        super(chatParticipation);
+        super(chatroom, sender);
         this.matchingResponseType = matchingResponseType;
     }
 
-    public MatchingResponseChatMessage(ChatParticipation chatParticipation,
+    public MatchingResponseChatMessage(Chatroom chatroom,
+                                       Member sender,
                                        MatchingResponseType matchingResponseType,
                                        String cancelMessage) {
-        this(chatParticipation, matchingResponseType);
+        this(chatroom, sender, matchingResponseType);
         this.cancelMessage = cancelMessage;
     }
 
-    public static MatchingResponseChatMessage createAcceptanceMessage(ChatParticipation chatParticipation) {
-        return new MatchingResponseChatMessage(chatParticipation, MatchingResponseType.ACCEPTED);
+    public static MatchingResponseChatMessage createAcceptanceMessage(Chatroom chatroom, Member sender) {
+        return new MatchingResponseChatMessage(chatroom, sender, MatchingResponseType.ACCEPTED);
     }
 
-    public static MatchingResponseChatMessage createRejectMessage(ChatParticipation chatParticipation,
+    public static MatchingResponseChatMessage createRejectMessage(Chatroom chatroom,
+                                                                  Member sender,
                                                                   String cancelMessage) {
-        return new MatchingResponseChatMessage(chatParticipation,
+        return new MatchingResponseChatMessage(chatroom,
+                sender,
                 MatchingResponseType.REJECTED,
                 cancelMessage);
     }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/TextChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/TextChatMessage.java
@@ -1,0 +1,10 @@
+package com.hf.healthfriend.domain.chat.entity.chatmessage;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("TEXT")
+public class TextChatMessage extends ChatMessage {
+    private String text;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/TextChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/TextChatMessage.java
@@ -1,10 +1,22 @@
 package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @DiscriminatorValue("TEXT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class TextChatMessage extends ChatMessage {
     private String text;
+
+    public TextChatMessage(Chatroom chatroom, Member sender, String text) {
+        super(chatroom, sender);
+        this.text = text;
+    }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.domain.chat.repository;
+
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatParticipationRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatParticipationRepository.java
@@ -1,0 +1,8 @@
+package com.hf.healthfriend.domain.chat.repository;
+
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.ChatParticipationId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, ChatParticipationId> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatroomRepository.java
@@ -1,0 +1,7 @@
+package com.hf.healthfriend.domain.chat.repository;
+
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
@@ -1,0 +1,42 @@
+package com.hf.healthfriend.domain.chat.service;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatParticipationRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatParticipationResponseDto;
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatService {
+    private final ChatroomRepository chatroomRepository;
+    private final ChatParticipationRepository chatParticipationRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    /**
+     * 채팅 신청. 채팅을 신청할 때, 채팅 신청 회원과 신청을 받는 회원 양쪽을 포함한 채팅방이 생성된다.
+     *
+     * @param dto 채팅 신청 정보가 담긴 DTO
+     * @return 새로 생성된 채팅방과 채팅 참여 정보가 담긴 DTO
+     */
+    public ChatParticipationResponseDto requestChat(ChatParticipationRequestDto dto) {
+        Chatroom chatroom = new Chatroom();
+        ChatParticipation requesterParticipation = new ChatParticipation(chatroom, new Member(dto.getRequesterId()));
+        ChatParticipation targetParticipation = new ChatParticipation(chatroom, new Member(dto.getChatTargetId()));
+        Chatroom newChatroom = this.chatroomRepository.save(chatroom);
+        return ChatParticipationResponseDto.builder()
+                .newChatroomId(newChatroom.getChatroomId())
+                .participantIds(List.of(dto.getChatTargetId(), dto.getRequesterId()))
+                .creatorId(dto.getRequesterId())
+                .build();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.member.entity;
 
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
 import com.hf.healthfriend.domain.matching.entity.Matching;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.domain.Tier;
@@ -132,6 +133,9 @@ public class Member implements UserDetails {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipation> chatParticipations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
 
     @Column(name = "review_score")
     private Double reviewScore = 0.0;

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.domain.member.entity;
 
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
 import com.hf.healthfriend.domain.matching.entity.Matching;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.domain.Tier;
@@ -129,6 +130,9 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "reviewee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewsReceived = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatParticipation> chatParticipations = new ArrayList<>();
+
     @Column(name = "review_score")
     private Double reviewScore = 0.0;
 
@@ -184,5 +188,9 @@ public class Member implements UserDetails {
 
     public Tier getTier() {
         return Tier.create(this.fitnessLevel, this.matchedCount);
+    }
+
+    public void addChatParticipation(ChatParticipation chatParticipation) {
+        this.chatParticipations.add(chatParticipation);
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatroomRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatroomRepository.java
@@ -1,0 +1,68 @@
+package com.hf.healthfriend.domain.chat.repository;
+
+import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
+import com.hf.healthfriend.testutil.SampleEntityGenerator;
+import com.hf.healthfriend.testutil.TestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({
+        TestConfig.class,
+        MysqlTestcontainerConfig.class
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Slf4j
+class TestChatroomRepository {
+
+    @Autowired
+    ChatroomRepository chatroomRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChatParticipationRepository chatParticipationRepository;
+
+    @Test
+    @DisplayName("save() - 채팅방 생성 시 Cascade 설정에 따라 ChatParticipation도 생성")
+    void save_checkCascade_success() {
+        // Given
+        Member requester = SampleEntityGenerator.generateSampleMember("requester@gmail.com", "REQ");
+        Member target = SampleEntityGenerator.generateSampleMember("target@gmail.com", "TAR");
+        this.memberRepository.save(requester);
+        this.memberRepository.save(target);
+
+        // When
+        Chatroom chatroom = new Chatroom();
+        ChatParticipation reqPart = new ChatParticipation(chatroom, requester);
+        ChatParticipation tarPart = new ChatParticipation(chatroom, target);
+        this.chatroomRepository.save(chatroom);
+
+        // Then
+        Optional<Chatroom> chatroomOp = this.chatroomRepository.findById(chatroom.getChatroomId());
+        assertThat(chatroomOp).isNotEmpty();
+        assertThat(this.chatParticipationRepository.findById(reqPart.getChatParticipationId()))
+                .isNotEmpty();
+        assertThat(this.chatParticipationRepository.findById(tarPart.getChatParticipationId()))
+                .isNotEmpty();
+
+        Chatroom findChatroom = chatroomOp.get();
+
+        assertThat(findChatroom.getParticipations().stream().map(ChatParticipation::getChatParticipationId))
+                .containsExactlyInAnyOrder(reqPart.getChatParticipationId(), tarPart.getChatParticipationId());
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/chat/service/TestChatService.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/service/TestChatService.java
@@ -1,0 +1,76 @@
+package com.hf.healthfriend.domain.chat.service;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatParticipationRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatParticipationResponseDto;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.testutil.SampleEntityGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestChatService {
+
+    @InjectMocks
+    ChatService chatService;
+
+    @Mock
+    ChatroomRepository chatroomRepository;
+
+    @Mock
+    ChatParticipationRepository chatParticipationRepository;
+
+    @Mock
+    ChatMessageRepository chatMessageRepository;
+
+    @Test
+    @DisplayName("requestChat - 채팅 참가 요청")
+    void requestChat_success() throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        // Given
+        final Long chatroomId = 5000L;
+        final Long requesterId = 1000L;
+        final Long receiverId = 2000L;
+        final Member sampleRequester = SampleEntityGenerator.generateSampleMember("requester@gmail.com", "REQ");
+        ReflectionTestUtils.setField(sampleRequester, "id", requesterId);
+        final Member sampleReceiver = SampleEntityGenerator.generateSampleMember("receiver@gmail.com", "REC");
+        ReflectionTestUtils.setField(sampleReceiver, "id", receiverId);
+
+        Chatroom mockReturnChatroom = new Chatroom(chatroomId);
+        ReflectionTestUtils.setField(mockReturnChatroom, "lastChatMessageId", 1000L);
+        ReflectionTestUtils.setField(mockReturnChatroom, "participations", List.of(sampleRequester, sampleReceiver));
+
+        when(this.chatroomRepository.save(any()))
+                .thenReturn(mockReturnChatroom);
+
+        // When
+        Constructor<ChatParticipationRequestDto> constructor = ChatParticipationRequestDto.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        ChatParticipationRequestDto requestDto = constructor.newInstance();
+        ReflectionTestUtils.setField(requestDto, "requesterId", requesterId);
+        ReflectionTestUtils.setField(requestDto, "chatTargetId", receiverId);
+        ChatParticipationResponseDto result = this.chatService.requestChat(requestDto);
+
+        // Then
+        assertThat(result.creatorId()).isEqualTo(requesterId);
+        assertThat(result.participantIds()).containsExactlyInAnyOrder(
+                requesterId, receiverId
+        );
+        assertThat(result.newChatroomId()).isEqualTo(mockReturnChatroom.getChatroomId());
+    }
+}

--- a/src/test/java/com/hf/healthfriend/testutil/MysqlTestcontainerConfig.java
+++ b/src/test/java/com/hf/healthfriend/testutil/MysqlTestcontainerConfig.java
@@ -1,0 +1,54 @@
+package com.hf.healthfriend.testutil;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+@TestConfiguration
+@Slf4j
+public class MysqlTestcontainerConfig {
+    private GenericContainer<?> mysqlContainer;
+
+    @PostConstruct
+    public void init() {
+        this.mysqlContainer = new GenericContainer<>("mysql:8.0.40")
+                .withExposedPorts(3306)
+                .withEnv(Map.of(
+                        "MYSQL_ROOT_PASSWORD", "1111",
+                        "MYSQL_DATABASE", "hf"
+                ));
+    }
+
+    @PreDestroy
+    public void destroy() {
+        this.mysqlContainer.stop();
+        this.mysqlContainer.close();
+        this.mysqlContainer = null;
+    }
+
+    @Bean
+    public DataSource testDataSource() {
+        this.mysqlContainer.start();
+        Integer mappedPort = this.mysqlContainer.getMappedPort(3306);
+        log.info("MySQL mappedPort={}", mappedPort);
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(
+                String.format(
+                        "jdbc:mysql://%s:%d/hf",
+                        this.mysqlContainer.getHost(),
+                        this.mysqlContainer.getMappedPort(3306)
+                )
+        );
+        dataSource.setUsername("root");
+        dataSource.setPassword("1111");
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        return dataSource;
+    }
+}


### PR DESCRIPTION
# 이슈 번호
#136 

## 개요
채팅에 필요한 엔티티 정의하고 채팅 신청을 구현했습니다. 서비스 로직만 구현했고, 추후 채팅 기능 구현이 어떻게 되는가에 따라 서비스 로직이 변경될 수 있겠습니다.