### PR TITLE
Fix/file upload bugg#151

### DIFF
--- a/dockerize.sh
+++ b/dockerize.sh
@@ -1,0 +1,20 @@
+AWS_ACCESS_KEY_ID=$1
+AWS_REGION=$2
+AWS_SECRET_ACCESS_KEY=$3
+AWS_SQS_ALARM_QUEUE_URL=$4
+AWS_SQS_DB_QUEUE_URL=$5
+
+MODE=$6:-auth
+
+docker container stop hf-backend-app || true
+docker container rm hf-backend-app || true
+
+./gradlew clean build -x test
+
+docker build -t hf-backend .
+
+if [ "$MODE" = "no-auth" ]; then
+  docker run --name hf-backend-app -p 8080:8080 -dit --rm -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_REGION=$AWS_REGION -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_SQS_ALARM_QUEUE_URL=$AWS_SQS_ALARM_QUEUE_URL -e AWS_SQS_DB_QUEUE_URL=$AWS_SQS_DB_QUEUE_URL --network=hf-net hf-backend
+else
+  docker run --name hf-backend-app -p 8080:8080 -dit --rm -e SPRING_PROFILES_ACTIVE=local-dev,secret,constants,priv -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_REGION=$AWS_REGION -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_SQS_ALARM_QUEUE_URL=$AWS_SQS_ALARM_QUEUE_URL -e AWS_SQS_DB_QUEUE_URL=$AWS_SQS_DB_QUEUE_URL --network=hf-net hf-backend
+fi

--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
             "/actuator/**",
             "/favicon.ico",
             "/oauth/token/**",
+            "/hf/files/**",
             "/files/**",
             "/hf/current-state",
 

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/MemberDto.java
@@ -3,7 +3,6 @@ package com.hf.healthfriend.domain.member.dto;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.domain.Tier;
 import com.hf.healthfriend.domain.member.entity.Member;
-import com.hf.healthfriend.domain.spec.dto.SpecDto;
 import com.hf.healthfriend.global.util.mapping.BeanMapping;
 import com.hf.healthfriend.global.util.mapping.MappingAttribute;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,7 +10,6 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -47,7 +45,7 @@ public class MemberDto {
     private Long matchedCount;
     private Tier tier;
 
-    public static MemberDto of(Member member) {
+    public static MemberDto of(Member member, String profileImageUrl) {
         return MemberDto.builder()
                 .memberId(member.getId())
                 .loginId(member.getLoginId())
@@ -56,7 +54,7 @@ public class MemberDto {
                 .email(member.getEmail())
                 .creationTime(member.getCreationTime())
                 .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
+                .profileImageUrl(profileImageUrl)
                 .cd1(member.getCd1())
                 .cd2(member.getCd2())
                 .cd3(member.getCd3())

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
 
         String profileImagePath = null;
         if (dto.getProfileImageFileExtension() != null) {
-            profileImagePath = this.fileUrlResolver.generateFilePathWithUuid(dto.getProfileImageFileExtension(), "image");
+            profileImagePath = this.fileUrlResolver.generateFilePathWithUuid(dto.getProfileImageFileExtension(), "files", "image");
             newMember.setProfileImageUrl(profileImagePath);
             log.info("id={}, profileImagePath={}", newMember.getId(), profileImagePath);
         } else {
@@ -86,7 +86,7 @@ public class MemberService {
     public MemberDto findMember(Long memberId) throws MemberNotFoundException {
         Member findMember = this.memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
-        return MemberDto.of(findMember);
+        return MemberDto.of(findMember, this.fileUrlResolver.resolveFileUrl(findMember.getProfileImageUrl()));
     }
 
     public MemberDto findMemberByLoginId(String loginId) throws MemberNotFoundException {
@@ -97,7 +97,7 @@ public class MemberService {
     public MemberDto findMemberByEmail(String email) throws MemberNotFoundException {
         Member findMember = this.memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberNotFoundException(email));
-        return MemberDto.of(findMember);
+        return MemberDto.of(findMember, this.fileUrlResolver.resolveFileUrl(findMember.getProfileImageUrl()));
     }
 
     public MemberUpdateResponseDto updateMember(Long memberId, MemberUpdateRequestDto requestDto) throws MemberNotFoundException {
@@ -105,7 +105,7 @@ public class MemberService {
         MemberUpdateDto updateDto = this.beanMapper.generateBean(requestDto, MemberUpdateDto.class);
         String profileImagePath = null;
         if (requestDto.getProfileImageFileExtension() != null) {
-            profileImagePath = this.fileUrlResolver.generateFilePathWithUuid(requestDto.getProfileImageFileExtension(), "image");
+            profileImagePath = this.fileUrlResolver.generateFilePathWithUuid(requestDto.getProfileImageFileExtension(), "files", "image");
             updateDto = updateDto.toBuilder()
                     .profileImageUrl(profileImagePath)
                     .build();

--- a/src/main/java/com/hf/healthfriend/domain/post/dto/response/PostGetResponse.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/dto/response/PostGetResponse.java
@@ -13,6 +13,7 @@ public record PostGetResponse(
         long writerId,
         String postCategory,
         String writerNickname,
+        String writerProfileImageUrl,
         Tier writerTier,
         String title,
         String content,
@@ -23,11 +24,12 @@ public record PostGetResponse(
         Long commentCount,
         List<CommentDto> comments
 ) {
-    public static PostGetResponse of(Post post, List<CommentDto> comments, String imagePath) {
+    public static PostGetResponse of(Post post, List<CommentDto> comments, String imagePath, String writerProfileImageUrl) {
         return PostGetResponse.builder()
                 .postId(post.getPostId())
                 .writerId(post.getMember().getId())
                 .writerNickname(post.getMember().getNickname())
+                .writerProfileImageUrl(writerProfileImageUrl)
                 .writerTier(post.getMember().getTier())
                 .postCategory(post.getCategory().name())
                 .title(post.getTitle())

--- a/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/service/PostService.java
@@ -67,7 +67,8 @@ public class PostService {
         }
         List<CommentDto> commentList = commentService.getCommentsOfPost(postId,sortType);
         String imagePath = fileUrlResolver.resolveFileUrl(post.getImagePath());
-        return PostGetResponse.of(post, commentList,imagePath);
+        String writerProfileImageUrl = fileUrlResolver.resolveFileUrl(post.getMember().getProfileImageUrl());
+        return PostGetResponse.of(post, commentList,imagePath, writerProfileImageUrl);
     }
 
     public void delete(Long postId) {

--- a/src/main/java/com/hf/healthfriend/global/file/FileUploadController.java
+++ b/src/main/java/com/hf/healthfriend/global/file/FileUploadController.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 @ConditionalOnProperty("local-file-upload")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/hr/files")
+@RequestMapping("/hf/files")
 public class FileUploadController {
     private final FileUploader fileUploader;
 

--- a/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUploader.java
+++ b/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUploader.java
@@ -48,8 +48,9 @@ public class LocalFileUploader implements FileUploader {
         byte[] buffer = new byte[BUFFER_SIZE];
         try (BufferedInputStream bis = new BufferedInputStream(is);
              BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(path))) {
-            while (bis.read(buffer) != -1) {
-                bos.write(buffer);
+            int read;
+            while ((read = bis.read(buffer)) != -1) {
+                bos.write(buffer, 0, read);
             }
         }
     }

--- a/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUrlResolver.java
+++ b/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUrlResolver.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
+import java.util.Arrays;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * 따로 Profile이 설정되지 않으면 Spring Bean으로 등록된다.
@@ -17,6 +19,17 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 public class LocalFileUrlResolver implements FileUrlResolver {
+    private static final Pattern DESIRED_PATTERN;
+
+    static {
+        String extensionPattern = String.join("|", Arrays.stream(ImageExtension.values())
+                .map(ImageExtension::value)
+                .toArray(String[]::new));
+        DESIRED_PATTERN = Pattern.compile(
+                String.format("(http|https)://(.+\\.)?.+(\\.\\w+)?(:\\d+)?/.+(%s)", extensionPattern)
+        );
+    }
+
     private static final String FILE_UPLOAD_URL_BASE = "/hr/files";
 
     private final String serverOrigin;
@@ -35,6 +48,9 @@ public class LocalFileUrlResolver implements FileUrlResolver {
     public String resolveFileUrl(String filePath) {
         if (!StringUtils.hasText(filePath)) {
             return null;
+        }
+        if (DESIRED_PATTERN.matcher(filePath).matches()) {
+            return filePath;
         }
         return this.serverOrigin + (filePath.startsWith("/") ? filePath : "/" + filePath);
     }

--- a/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUrlResolver.java
+++ b/src/main/java/com/hf/healthfriend/global/file/local/LocalFileUrlResolver.java
@@ -30,7 +30,7 @@ public class LocalFileUrlResolver implements FileUrlResolver {
         );
     }
 
-    private static final String FILE_UPLOAD_URL_BASE = "/hr/files";
+    private static final String FILE_UPLOAD_URL_BASE = "/hf/files";
 
     private final String serverOrigin;
 

--- a/src/test/java/com/hf/healthfriend/global/file/local/TestLocalFileUrlResolver.java
+++ b/src/test/java/com/hf/healthfriend/global/file/local/TestLocalFileUrlResolver.java
@@ -52,7 +52,8 @@ class TestLocalFileUrlResolver {
                     "http://localhost:8080/image/filename.jpg;image/filename.jpg",
                     "http://localhost:8080/image/filename.jpg;/image/filename.jpg",
                     "http://localhost:8080/filename.jpg;filename.jpg",
-                    "http://localhost:8080/filename.jpg;/filename.jpg"
+                    "http://localhost:8080/filename.jpg;/filename.jpg",
+                    "http://localhost:8080/filename.jpg;http://localhost:8080/filename.jpg"
             },
             delimiter = ';'
     )


### PR DESCRIPTION
# 이슈번호
#151 

## 개요
파일 업로드 관련된 버그 수정

## 변경사항
- 1
![image](https://github.com/user-attachments/assets/81ef3ed7-7986-467c-b448-b8a37eb5a983)
파일 업로드 엔드포인트 ```/hf```로 시작하도록 변경 (이 부분은 프론트 코드 고칠 필요 없어요!)

- 2
![image](https://github.com/user-attachments/assets/91376bc8-bd20-434e-be98-c5be13cd8166)
글 조회 시 작성자 프로필 이미지도 데이터에 포함됨

- 3
컨테이너 생성 쉘 스크립트 작성 (귀찮게 컨테이너 삭제하고, 이미지 빌드하고, 컨테이너 만들고 이런 짓 안 해도 됨)
커맨드는 슬랙에다 올리겠습니다

- 4
기타 버그 수정: 403 Unauthorized, 파일 업로드 시 깨짐 등