### PR TITLE
Fix/member profile view 404

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/member/repository/querydsl/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/querydsl/MemberCustomRepositoryImpl.java
@@ -196,7 +196,7 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
                 .leftJoin(this.spec).on(this.spec.member.eq(this.member))
                 .where(this.member.id.eq(memberId),
                         this.member.isDeleted.isFalse(),
-                        this.spec.isDeleted.isFalse())
+                        this.spec.isDeleted.isFalse().or(this.spec.isNull()))
                 .orderBy(this.spec.startDate.desc(), this.spec.endDate.desc().nullsFirst())
                 .transform(GroupBy.groupBy(this.member.id).list(
                         Projections.constructor(

--- a/src/test/java/com/hf/healthfriend/domain/member/repository/MemberCustomRepositoryImlTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/repository/MemberCustomRepositoryImlTest.java
@@ -4,6 +4,7 @@ import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.dto.request.MembersRecommendRequest;
 import com.hf.healthfriend.domain.member.dto.response.MemberSearchResponse;
 import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.dto.ProfileQueryResultDto;
 import com.hf.healthfriend.domain.member.repository.querydsl.MemberCustomRepositoryImpl;
 import com.hf.healthfriend.domain.wish.entity.Wish;
 import com.hf.healthfriend.domain.wish.repository.WishRepository;
@@ -152,5 +153,19 @@ public class MemberCustomRepositoryImlTest {
         assertThat(member.getId()).isEqualTo(sampleMember.getId());
         assertThat(member.getEmail()).isEqualTo(sampleMember.getEmail());
         assertThat(member.getNickname()).isEqualTo(sampleMember.getNickname());
+    }
+
+    @Test
+    @DisplayName("findProfileByMemberId() - 스펙, 리뷰가 없는 회원 조회 시 쿼리 성공해야 함")
+    void findProfileByMemberId_noReviewOrSpecs_success() {
+        // Given
+        Member sampleMember = SampleEntityGenerator.generateSampleMember("sample1@gmail.com", "sample1");
+        this.memberRepository.save(sampleMember);
+
+        // When
+        Optional<ProfileQueryResultDto> result = this.memberCustomRepository.findProfileByMemberId(sampleMember.getId());
+
+        // Then
+        assertThat(result).isNotEmpty();
     }
 }


### PR DESCRIPTION
# 개요
회원 프로필 조회 시 회원의 spec을 가져오는데, spec이 없어도 회원이 존재하면 회원 프로필 정보를 응답해야 하지만, spec이 없을 경우 404 에러가 발생. 이러한 버그를 해결함