### PR TITLE
Feature/chat send#136

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/chat/constant/ChatMessageType.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/constant/ChatMessageType.java
@@ -1,0 +1,17 @@
+package com.hf.healthfriend.domain.chat.constant;
+
+import com.hf.healthfriend.domain.chat.service.delegator.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+public enum ChatMessageType {
+    IMAGE(ImageChatMessageProcessor.class),
+    MATCHING_REQUEST(MatchingRequestChatMessageProcessor.class),
+    MATCHING_RESPONSE(MatchingResponseChatMessageProcessor.class),
+    TEXT(TextChatMessageProcessor.class);
+
+    private final Class<? extends ChatMessageProcessor> processorClass;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/controller/ChatMessagingController.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/controller/ChatMessagingController.java
@@ -1,0 +1,47 @@
+package com.hf.healthfriend.domain.chat.controller;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.ChatParticipationRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatParticipationResponseDto;
+import com.hf.healthfriend.domain.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessagingController {
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/request")
+    public void requestChat(@Payload ChatParticipationRequestDto dto) {
+        log.debug("payload={}", dto);
+        ChatParticipationResponseDto result = this.chatService.requestChat(dto);
+        result.participantIds().forEach((participantId) ->
+                this.messagingTemplate.convertAndSendToUser(String.valueOf(participantId),
+                        "chat/request", result));
+    }
+
+
+    @MessageMapping("/chat/messages/{chatroomId}")
+    public void sendChatMessage(@DestinationVariable("chatroomId") Long chatroomId,
+                                @Payload ChatMessageSendRequestDto<Object> messageDto) {
+        ChatMessageSendResponseDto result = this.chatService.sendMessage(chatroomId, messageDto);
+        if (log.isDebugEnabled()) {
+            log.debug("request chatroomId={}", chatroomId);
+            log.debug("request payload={}", messageDto);
+            log.debug("response={}", result);
+        }
+        this.messagingTemplate.convertAndSend(
+                "/hf/topic/chat/messages/" + result.chatroomId(),
+                result
+        );
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/ChatMessageSendRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/ChatMessageSendRequestDto.java
@@ -1,0 +1,16 @@
+package com.hf.healthfriend.domain.chat.dto.request;
+
+import com.hf.healthfriend.domain.chat.constant.ChatMessageType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class ChatMessageSendRequestDto<T> {
+    private Long senderId;
+    private ChatMessageType chatMessageType;
+    private T content;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/ImageChatMessageSendRequestContent.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/ImageChatMessageSendRequestContent.java
@@ -1,0 +1,17 @@
+package com.hf.healthfriend.domain.chat.dto.request.content;
+
+import com.hf.healthfriend.global.file.image.ImageExtension;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class ImageChatMessageSendRequestContent {
+
+    @NotNull
+    private ImageExtension imageExtension;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/MatchingRequestChatMessageSendRequestContent.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/MatchingRequestChatMessageSendRequestContent.java
@@ -1,0 +1,31 @@
+package com.hf.healthfriend.domain.chat.dto.request.content;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class MatchingRequestChatMessageSendRequestContent {
+
+    @NotNull
+    private Long matchingTargetId;
+
+    @NotNull
+    @Future
+    private LocalDateTime meetingTime;
+
+    @NotNull
+    @NotEmpty
+    private String meetingPlace;
+
+    @NotNull
+    private String meetingPlaceAddress;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/MatchingResponseChatMessageSendRequestContent.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/MatchingResponseChatMessageSendRequestContent.java
@@ -1,0 +1,24 @@
+package com.hf.healthfriend.domain.chat.dto.request.content;
+
+import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class MatchingResponseChatMessageSendRequestContent {
+
+    @NotNull
+    private MatchingResponseType matchingResponseType;
+
+    @NotNull
+    private Long matchingId;
+
+    @Nullable
+    private String cancelMessage;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/TextChatMessageSendRequestContent.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/request/content/TextChatMessageSendRequestContent.java
@@ -1,0 +1,16 @@
+package com.hf.healthfriend.domain.chat.dto.request.content;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class TextChatMessageSendRequestContent {
+
+    @NotEmpty
+    private String text;
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/dto/response/ChatMessageSendResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/dto/response/ChatMessageSendResponseDto.java
@@ -1,0 +1,16 @@
+package com.hf.healthfriend.domain.chat.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatMessageSendResponseDto(
+        Long chatMessageId,
+        Long chatroomId,
+        Long senderId,
+        LocalDateTime creationTime,
+        LocalDateTime lastModified,
+        Object content
+) {
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
@@ -39,7 +39,6 @@ public class ChatParticipation extends BaseTimeEntity {
         this(new ChatParticipationId(chatroom.getChatroomId(), member.getId()));
         this.chatroom = chatroom;
         this.member = member;
-        this.chatroom.addChatParticipation(this);
         this.member.addChatParticipation(this);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/ChatParticipation.java
@@ -39,6 +39,5 @@ public class ChatParticipation extends BaseTimeEntity {
         this(new ChatParticipationId(chatroom.getChatroomId(), member.getId()));
         this.chatroom = chatroom;
         this.member = member;
-        this.member.addChatParticipation(this);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
@@ -29,7 +29,9 @@ public class Chatroom extends BaseTimeEntity {
     @OneToMany(mappedBy = "chatroom", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ChatMessage> chatMessages = new ArrayList<>();
 
-    private Long lastChatMessageId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_chat_message_id")
+    private ChatMessage lastChatMessage;
 
     public static Chatroom newChatroom(Member... participants) {
         Chatroom newChatroom = new Chatroom();
@@ -49,5 +51,9 @@ public class Chatroom extends BaseTimeEntity {
 
     public void addChatParticipation(ChatParticipation chatParticipation) {
         this.participations.add(chatParticipation);
+    }
+
+    public void updateLastChatMessage(ChatMessage chatMessage) {
+        this.lastChatMessage = chatMessage;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/Chatroom.java
@@ -2,11 +2,13 @@ package com.hf.healthfriend.domain.chat.entity;
 
 import com.hf.healthfriend.domain.BaseTimeEntity;
 import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -28,6 +30,14 @@ public class Chatroom extends BaseTimeEntity {
     private List<ChatMessage> chatMessages = new ArrayList<>();
 
     private Long lastChatMessageId;
+
+    public static Chatroom newChatroom(Member... participants) {
+        Chatroom newChatroom = new Chatroom();
+        newChatroom.participations = Arrays.stream(participants)
+                .map((m) -> new ChatParticipation(newChatroom, m))
+                .toList();
+        return newChatroom;
+    }
 
     public Chatroom(Long chatroomId) {
         this.chatroomId = chatroomId;

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-// 하나의 외래키만으로 Member, Chatroom 두 엔티티에 접근할 수 있으므로 ChatParticipation에 매핑
 @Entity
 @Inheritance
 @DiscriminatorColumn(name = "message_type")

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/ChatMessage.java
@@ -1,7 +1,6 @@
 package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
 import com.hf.healthfriend.domain.BaseTimeEntity;
-import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.*;
@@ -26,7 +25,7 @@ public abstract class ChatMessage extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member sender;
 
     // 서비스에 일대일 채팅만 있으므로 ChatMessage 엔티티에서 채팅 읽었는지 여부 체크
     // 나중에 기능이 확장될 경우, 크게 어려움 없이 기능 확장할 수 있을 듯
@@ -38,7 +37,7 @@ public abstract class ChatMessage extends BaseTimeEntity {
 
     protected ChatMessage(Chatroom chatroom, Member sender) {
         this.chatroom = chatroom;
-        this.member = sender;
+        this.sender = sender;
     }
 
     /**
@@ -49,7 +48,7 @@ public abstract class ChatMessage extends BaseTimeEntity {
      */
     public void readIfOpponent(Long readerId) {
         // ID만 조회하는 것이기 때문에 추가 쿼리는 날아가지 않음
-        if (this.member.getId().equals(readerId)) {
+        if (this.sender.getId().equals(readerId)) {
             this.readByOpponent = true;
         }
     }

--- a/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/entity/chatmessage/MatchingRequestChatMessage.java
@@ -1,6 +1,5 @@
 package com.hf.healthfriend.domain.chat.entity.chatmessage;
 
-import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.member.entity.Member;
 import jakarta.persistence.DiscriminatorValue;
@@ -14,16 +13,22 @@ import java.time.LocalDateTime;
 @DiscriminatorValue("MAT_REQ")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MatchingRequestChatMessage extends ChatMessage {
-    private LocalDateTime meetingDate;
-    private String place;
+    private LocalDateTime meetingTime;
+    private String meetingPlace;
+    private String meetingPlaceAddress;
 
     public MatchingRequestChatMessage(Long chatMessageId) {
         super(chatMessageId);
     }
 
-    public MatchingRequestChatMessage(Chatroom chatroom, Member sender, LocalDateTime meetingDate, String place) {
+    public MatchingRequestChatMessage(Chatroom chatroom,
+                                      Member sender,
+                                      LocalDateTime meetingTime,
+                                      String meetingPlace,
+                                      String meetingPlaceAddress) {
         super(chatroom, sender);
-        this.meetingDate = meetingDate;
-        this.place = place;
+        this.meetingTime = meetingTime;
+        this.meetingPlace = meetingPlace;
+        this.meetingPlaceAddress = meetingPlaceAddress;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,8 @@
 package com.hf.healthfriend.domain.chat.repository;
 
 import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import com.hf.healthfriend.domain.chat.repository.custom.ChatMessageCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageCustomRepository {
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/ChatroomRepository.java
@@ -1,7 +1,8 @@
 package com.hf.healthfriend.domain.chat.repository;
 
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.repository.custom.ChatroomCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long>, ChatroomCustomRepository {
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepository.java
@@ -1,0 +1,10 @@
+package com.hf.healthfriend.domain.chat.repository.custom;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+
+public interface ChatMessageCustomRepository {
+
+    <D extends ChatMessage> D saveMessageWithChatroomId(Long chatroomId,
+                                                        ChatMessageSendRequestDto<?> dto);
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepositoryImpl.java
@@ -21,11 +21,11 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
     @Override
     public <D extends ChatMessage> D saveMessageWithChatroomId(Long chatroomId,
                                                                ChatMessageSendRequestDto<?> dto) {
-        Chatroom chatroomReference = this.em.getReference(Chatroom.class, chatroomId);
+        Chatroom chatroom = this.em.find(Chatroom.class, chatroomId);
         Member senderReference = this.em.getReference(Member.class, dto.getSenderId());
         ChatMessage chatMessage = switch (dto.getChatMessageType()) {
             case TEXT ->
-                new TextChatMessage(chatroomReference,
+                new TextChatMessage(chatroom,
                         senderReference,
                         ((TextChatMessageSendRequestContent)dto.getContent()).getText());
             case IMAGE -> {
@@ -35,7 +35,7 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
             case MATCHING_REQUEST -> {
                 MatchingRequestChatMessageSendRequestContent content =
                         (MatchingRequestChatMessageSendRequestContent) dto.getContent();
-                yield new MatchingRequestChatMessage(chatroomReference,
+                yield new MatchingRequestChatMessage(chatroom,
                         senderReference,
                         content.getMeetingTime(),
                         content.getMeetingPlace(),
@@ -46,14 +46,15 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
                         (MatchingResponseChatMessageSendRequestContent) dto.getContent();
                 yield switch (content.getMatchingResponseType()) {
                     case ACCEPTED ->
-                            MatchingResponseChatMessage.createAcceptanceMessage(chatroomReference, senderReference);
+                            MatchingResponseChatMessage.createAcceptanceMessage(chatroom, senderReference);
                     case REJECTED ->
-                        MatchingResponseChatMessage.createRejectMessage(chatroomReference,
+                        MatchingResponseChatMessage.createRejectMessage(chatroom,
                                 senderReference, content.getCancelMessage());
                 };
             }
         };
         this.em.persist(chatMessage);
+        chatroom.updateLastChatMessage(chatMessage);
         return (D) chatMessage;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatMessageCustomRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.hf.healthfriend.domain.chat.repository.custom;
+
+import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.ImageChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingRequestChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingResponseChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.TextChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.*;
+import com.hf.healthfriend.domain.member.entity.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomRepository {
+    private final EntityManager em;
+
+    @Override
+    public <D extends ChatMessage> D saveMessageWithChatroomId(Long chatroomId,
+                                                               ChatMessageSendRequestDto<?> dto) {
+        Chatroom chatroomReference = this.em.getReference(Chatroom.class, chatroomId);
+        Member senderReference = this.em.getReference(Member.class, dto.getSenderId());
+        ChatMessage chatMessage = switch (dto.getChatMessageType()) {
+            case TEXT ->
+                new TextChatMessage(chatroomReference,
+                        senderReference,
+                        ((TextChatMessageSendRequestContent)dto.getContent()).getText());
+            case IMAGE -> {
+                // TODO: 이미지를 어떻게 할 것인가
+                throw new UnsupportedOperationException();
+            }
+            case MATCHING_REQUEST -> {
+                MatchingRequestChatMessageSendRequestContent content =
+                        (MatchingRequestChatMessageSendRequestContent) dto.getContent();
+                yield new MatchingRequestChatMessage(chatroomReference,
+                        senderReference,
+                        content.getMeetingTime(),
+                        content.getMeetingPlace(),
+                        content.getMeetingPlaceAddress());
+            }
+            case MATCHING_RESPONSE -> {
+                MatchingResponseChatMessageSendRequestContent content =
+                        (MatchingResponseChatMessageSendRequestContent) dto.getContent();
+                yield switch (content.getMatchingResponseType()) {
+                    case ACCEPTED ->
+                            MatchingResponseChatMessage.createAcceptanceMessage(chatroomReference, senderReference);
+                    case REJECTED ->
+                        MatchingResponseChatMessage.createRejectMessage(chatroomReference,
+                                senderReference, content.getCancelMessage());
+                };
+            }
+        };
+        this.em.persist(chatMessage);
+        return (D) chatMessage;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatroomCustomRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatroomCustomRepository.java
@@ -1,0 +1,9 @@
+package com.hf.healthfriend.domain.chat.repository.custom;
+
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
+
+public interface ChatroomCustomRepository {
+
+    Chatroom saveWithParticipants(Member... participants);
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatroomCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/repository/custom/ChatroomCustomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.hf.healthfriend.domain.chat.repository.custom;
+
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.member.entity.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatroomCustomRepositoryImpl implements ChatroomCustomRepository {
+    private final EntityManager em;
+
+    @Override
+    public Chatroom saveWithParticipants(Member... participants) {
+        Chatroom newChatroom = Chatroom.newChatroom(
+                Arrays.stream(participants)
+                        .map((e) -> this.em.getReference(Member.class, e.getId()))
+                        .toArray(Member[]::new)
+        );
+        this.em.persist(newChatroom);
+        return newChatroom;
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
@@ -29,9 +29,7 @@ public class ChatService {
      * @return 새로 생성된 채팅방과 채팅 참여 정보가 담긴 DTO
      */
     public ChatParticipationResponseDto requestChat(ChatParticipationRequestDto dto) {
-        Chatroom chatroom = new Chatroom();
-        ChatParticipation requesterParticipation = new ChatParticipation(chatroom, new Member(dto.getRequesterId()));
-        ChatParticipation targetParticipation = new ChatParticipation(chatroom, new Member(dto.getChatTargetId()));
+        Chatroom chatroom = Chatroom.newChatroom(new Member(dto.getRequesterId()), new Member(dto.getChatTargetId()));
         Chatroom newChatroom = this.chatroomRepository.save(chatroom);
         return ChatParticipationResponseDto.builder()
                 .newChatroomId(newChatroom.getChatroomId())

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
@@ -1,12 +1,15 @@
 package com.hf.healthfriend.domain.chat.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
 import com.hf.healthfriend.domain.chat.dto.request.ChatParticipationRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
 import com.hf.healthfriend.domain.chat.dto.response.ChatParticipationResponseDto;
-import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
 import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
 import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
+import com.hf.healthfriend.domain.chat.service.delegator.ChatMessageProcessor;
 import com.hf.healthfriend.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +24,7 @@ public class ChatService {
     private final ChatroomRepository chatroomRepository;
     private final ChatParticipationRepository chatParticipationRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageProcessor chatMessageProcessor;
 
     /**
      * 채팅 신청. 채팅을 신청할 때, 채팅 신청 회원과 신청을 받는 회원 양쪽을 포함한 채팅방이 생성된다.
@@ -36,5 +40,9 @@ public class ChatService {
                 .participantIds(List.of(dto.getChatTargetId(), dto.getRequesterId()))
                 .creatorId(dto.getRequesterId())
                 .build();
+    }
+
+    public ChatMessageSendResponseDto sendMessage(Long chatroomId, ChatMessageSendRequestDto<Object> dto) {
+        return this.chatMessageProcessor.sendMessage(chatroomId, dto);
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/ChatService.java
@@ -1,6 +1,5 @@
 package com.hf.healthfriend.domain.chat.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
 import com.hf.healthfriend.domain.chat.dto.request.ChatParticipationRequestDto;
 import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
@@ -14,10 +13,12 @@ import com.hf.healthfriend.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class ChatService {
@@ -33,8 +34,8 @@ public class ChatService {
      * @return 새로 생성된 채팅방과 채팅 참여 정보가 담긴 DTO
      */
     public ChatParticipationResponseDto requestChat(ChatParticipationRequestDto dto) {
-        Chatroom chatroom = Chatroom.newChatroom(new Member(dto.getRequesterId()), new Member(dto.getChatTargetId()));
-        Chatroom newChatroom = this.chatroomRepository.save(chatroom);
+        Chatroom newChatroom = this.chatroomRepository.saveWithParticipants(new Member(dto.getRequesterId()),
+                new Member(dto.getChatTargetId()));
         return ChatParticipationResponseDto.builder()
                 .newChatroomId(newChatroom.getChatroomId())
                 .participantIds(List.of(dto.getChatTargetId(), dto.getRequesterId()))

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/AbstractChatMessageProcessorDelegator.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/AbstractChatMessageProcessorDelegator.java
@@ -1,0 +1,22 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractChatMessageProcessorDelegator<C> implements ChatMessageProcessor {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public ChatMessageSendResponseDto sendMessage(Long chatroomId, ChatMessageSendRequestDto<Object> dto) {
+        return processSendingMessage(chatroomId, this.objectMapper.convertValue(dto, getTypeReference()));
+    }
+
+    protected abstract TypeReference<ChatMessageSendRequestDto<C>> getTypeReference();
+
+    protected abstract ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<C> dto);
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/ChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/ChatMessageProcessor.java
@@ -1,0 +1,9 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+
+public interface ChatMessageProcessor {
+
+    ChatMessageSendResponseDto sendMessage(Long chatroomId, ChatMessageSendRequestDto<Object> dto);
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/DelegatingChatMessageProcessorBean.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/DelegatingChatMessageProcessorBean.java
@@ -1,0 +1,65 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.hf.healthfriend.domain.chat.constant.ChatMessageType;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DelegatingChatMessageProcessorBean implements ChatMessageProcessor {
+    private final Map<ChatMessageType, ChatMessageProcessor> delegators = new HashMap<>();
+    private final ApplicationContext applicationContext;
+
+    @PostConstruct
+    public void init() throws InvocationTargetException, InstantiationException, IllegalAccessException {
+        ChatMessageType[] allTypes = ChatMessageType.values();
+        for (ChatMessageType type : allTypes) {
+            Constructor<?>[] constructors = type.getProcessorClass().getDeclaredConstructors();
+            if (constructors.length > 1) {
+                throw new IllegalStateException("쓸데없이 많은 생성자: " + type); // TODO: 구체적인 예외
+            }
+
+            Constructor<?> constructor = constructors[0];
+            log.debug("ChatMessageType={}", type);
+            log.debug("constructor={}", constructor);
+            log.debug("beans={}", Arrays.stream(constructor.getParameterTypes())
+                    .map((t) ->
+                            t.isAssignableFrom(Collection.class)
+                                    ? this.applicationContext.getBeansOfType(t)
+                                    : this.applicationContext.getBean(t)).toList());
+            log.debug("constructor bean len={}", Arrays.stream(constructor.getParameterTypes())
+                    .map((t) ->
+                            t.isAssignableFrom(Collection.class)
+                                    ? this.applicationContext.getBeansOfType(t)
+                                    : this.applicationContext.getBean(t)).toList().size());
+            ChatMessageProcessor processorInstance = (ChatMessageProcessor) constructor.newInstance(
+                    Arrays.stream(constructor.getParameterTypes())
+                            .map((t) ->
+                                    t.isAssignableFrom(Collection.class)
+                                            ? this.applicationContext.getBeansOfType(t)
+                                            : this.applicationContext.getBean(t))
+                            .toArray()
+            );
+            this.delegators.put(type, processorInstance);
+        }
+    }
+
+    @Override
+    public ChatMessageSendResponseDto sendMessage(Long chatroomId, ChatMessageSendRequestDto<Object> dto) {
+        ChatMessageProcessor processor = this.delegators.get(dto.getChatMessageType());
+        return processor.sendMessage(chatroomId, dto);
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/DelegatingChatMessageProcessorBean.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/DelegatingChatMessageProcessorBean.java
@@ -35,16 +35,6 @@ public class DelegatingChatMessageProcessorBean implements ChatMessageProcessor 
             Constructor<?> constructor = constructors[0];
             log.debug("ChatMessageType={}", type);
             log.debug("constructor={}", constructor);
-            log.debug("beans={}", Arrays.stream(constructor.getParameterTypes())
-                    .map((t) ->
-                            t.isAssignableFrom(Collection.class)
-                                    ? this.applicationContext.getBeansOfType(t)
-                                    : this.applicationContext.getBean(t)).toList());
-            log.debug("constructor bean len={}", Arrays.stream(constructor.getParameterTypes())
-                    .map((t) ->
-                            t.isAssignableFrom(Collection.class)
-                                    ? this.applicationContext.getBeansOfType(t)
-                                    : this.applicationContext.getBean(t)).toList().size());
             ChatMessageProcessor processorInstance = (ChatMessageProcessor) constructor.newInstance(
                     Arrays.stream(constructor.getParameterTypes())
                             .map((t) ->

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/ImageChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/ImageChatMessageProcessor.java
@@ -1,0 +1,37 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.ImageChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.global.file.FileUrlResolver;
+
+public class ImageChatMessageProcessor extends AbstractChatMessageProcessorDelegator<ImageChatMessageSendRequestContent> {
+    private static final TypeReference<ChatMessageSendRequestDto<ImageChatMessageSendRequestContent>> DTO_TYPE =
+            new TypeReference<>() {
+            };
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final FileUrlResolver fileUrlResolver;
+
+    public ImageChatMessageProcessor(ObjectMapper objectMapper,
+                                     ChatMessageRepository chatMessageRepository,
+                                     FileUrlResolver fileUrlResolver) {
+        super(objectMapper);
+        this.chatMessageRepository = chatMessageRepository;
+        this.fileUrlResolver = fileUrlResolver;
+    }
+
+    @Override
+    protected TypeReference<ChatMessageSendRequestDto<ImageChatMessageSendRequestContent>> getTypeReference() {
+        return DTO_TYPE;
+    }
+
+    @Override
+    protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<ImageChatMessageSendRequestContent> dto) {
+        // TODO: 채팅방 사진 업로드를 어떻게 다룰까?
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingRequestChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingRequestChatMessageProcessor.java
@@ -1,0 +1,72 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingRequestChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingRequestChatMessage;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.matching.dto.request.MatchingRequestDto;
+import com.hf.healthfriend.domain.matching.service.MatchingService;
+import com.hf.healthfriend.domain.member.entity.Member;
+
+import java.util.Map;
+
+public class MatchingRequestChatMessageProcessor
+        extends AbstractChatMessageProcessorDelegator<MatchingRequestChatMessageSendRequestContent> {
+    private static final TypeReference<ChatMessageSendRequestDto<MatchingRequestChatMessageSendRequestContent>> DTO_TYPE =
+            new TypeReference<>() {
+            };
+
+    private final MatchingService matchingService;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public MatchingRequestChatMessageProcessor(ObjectMapper objectMapper,
+                                               MatchingService matchingService,
+                                               ChatMessageRepository chatMessageRepository) {
+        super(objectMapper);
+        this.matchingService = matchingService;
+        this.chatMessageRepository = chatMessageRepository;
+    }
+
+    @Override
+    protected TypeReference<ChatMessageSendRequestDto<MatchingRequestChatMessageSendRequestContent>> getTypeReference() {
+        return DTO_TYPE;
+    }
+
+    @Override
+    protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<MatchingRequestChatMessageSendRequestContent> dto) {
+        MatchingRequestChatMessage chatMessage = new MatchingRequestChatMessage(
+                new Chatroom(chatroomId),
+                new Member(dto.getSenderId()),
+                dto.getContent().getMeetingTime(),
+                dto.getContent().getMeetingPlace(),
+                dto.getContent().getMeetingPlace()
+        );
+        MatchingRequestChatMessage saved = this.chatMessageRepository.save(chatMessage);
+
+        Long generatedMatchingId = this.matchingService.requestMatching(MatchingRequestDto.builder()
+                .requesterId(dto.getSenderId())
+                .targetId(dto.getContent().getMatchingTargetId())
+                .meetingPlace(dto.getContent().getMeetingPlace())
+                .meetingPlaceAddress(dto.getContent().getMeetingPlaceAddress())
+                .meetingTime(dto.getContent().getMeetingTime())
+                .build());
+
+        return ChatMessageSendResponseDto.builder()
+                .chatMessageId(saved.getChatMessageId())
+                .chatroomId(chatroomId)
+                .senderId(dto.getSenderId())
+                .creationTime(saved.getCreationTime())
+                .lastModified(saved.getLastModified())
+                .content(Map.of(
+                        "matchingId", generatedMatchingId,
+                        "meetingTime", dto.getContent().getMeetingTime(),
+                        "meetingPlace", dto.getContent().getMeetingPlace(),
+                        "meetingPlaceAddress", dto.getContent().getMeetingPlaceAddress()
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingRequestChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingRequestChatMessageProcessor.java
@@ -5,12 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
 import com.hf.healthfriend.domain.chat.dto.request.content.MatchingRequestChatMessageSendRequestContent;
 import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
-import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingRequestChatMessage;
 import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
 import com.hf.healthfriend.domain.matching.dto.request.MatchingRequestDto;
 import com.hf.healthfriend.domain.matching.service.MatchingService;
-import com.hf.healthfriend.domain.member.entity.Member;
 
 import java.util.Map;
 
@@ -38,14 +36,7 @@ public class MatchingRequestChatMessageProcessor
 
     @Override
     protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<MatchingRequestChatMessageSendRequestContent> dto) {
-        MatchingRequestChatMessage chatMessage = new MatchingRequestChatMessage(
-                new Chatroom(chatroomId),
-                new Member(dto.getSenderId()),
-                dto.getContent().getMeetingTime(),
-                dto.getContent().getMeetingPlace(),
-                dto.getContent().getMeetingPlace()
-        );
-        MatchingRequestChatMessage saved = this.chatMessageRepository.save(chatMessage);
+        MatchingRequestChatMessage saved = this.chatMessageRepository.saveMessageWithChatroomId(chatroomId, dto);
 
         Long generatedMatchingId = this.matchingService.requestMatching(MatchingRequestDto.builder()
                 .requesterId(dto.getSenderId())

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingResponseChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingResponseChatMessageProcessor.java
@@ -5,12 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
 import com.hf.healthfriend.domain.chat.dto.request.content.MatchingResponseChatMessageSendRequestContent;
 import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
-import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingResponseChatMessage;
 import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
 import com.hf.healthfriend.domain.matching.constant.MatchingStatus;
 import com.hf.healthfriend.domain.matching.service.MatchingService;
-import com.hf.healthfriend.domain.member.entity.Member;
 
 import java.util.Map;
 
@@ -38,15 +36,7 @@ public class MatchingResponseChatMessageProcessor
 
     @Override
     protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<MatchingResponseChatMessageSendRequestContent> dto) {
-        MatchingResponseChatMessage chatMessage =
-                switch (dto.getContent().getMatchingResponseType()) {
-                    case ACCEPTED -> MatchingResponseChatMessage.createAcceptanceMessage(new Chatroom(chatroomId),
-                            new Member(dto.getSenderId()));
-                    case REJECTED -> MatchingResponseChatMessage.createRejectMessage(new Chatroom(chatroomId),
-                            new Member(dto.getSenderId()),
-                            dto.getContent().getCancelMessage());
-                };
-        MatchingResponseChatMessage saved = this.chatMessageRepository.save(chatMessage);
+        MatchingResponseChatMessage saved = this.chatMessageRepository.saveMessageWithChatroomId(chatroomId, dto);
 
         this.matchingService.updateMatchingStatus(dto.getContent().getMatchingId(),
                 switch (dto.getContent().getMatchingResponseType()) {

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingResponseChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/MatchingResponseChatMessageProcessor.java
@@ -1,0 +1,69 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingResponseChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingResponseChatMessage;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.matching.constant.MatchingStatus;
+import com.hf.healthfriend.domain.matching.service.MatchingService;
+import com.hf.healthfriend.domain.member.entity.Member;
+
+import java.util.Map;
+
+public class MatchingResponseChatMessageProcessor
+        extends AbstractChatMessageProcessorDelegator<MatchingResponseChatMessageSendRequestContent> {
+    private static final TypeReference<ChatMessageSendRequestDto<MatchingResponseChatMessageSendRequestContent>> DTO_TYPE =
+            new TypeReference<>() {
+            };
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final MatchingService matchingService;
+
+    public MatchingResponseChatMessageProcessor(ObjectMapper objectMapper,
+                                                ChatMessageRepository chatMessageRepository,
+                                                MatchingService matchingService) {
+        super(objectMapper);
+        this.chatMessageRepository = chatMessageRepository;
+        this.matchingService = matchingService;
+    }
+
+    @Override
+    protected TypeReference<ChatMessageSendRequestDto<MatchingResponseChatMessageSendRequestContent>> getTypeReference() {
+        return DTO_TYPE;
+    }
+
+    @Override
+    protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<MatchingResponseChatMessageSendRequestContent> dto) {
+        MatchingResponseChatMessage chatMessage =
+                switch (dto.getContent().getMatchingResponseType()) {
+                    case ACCEPTED -> MatchingResponseChatMessage.createAcceptanceMessage(new Chatroom(chatroomId),
+                            new Member(dto.getSenderId()));
+                    case REJECTED -> MatchingResponseChatMessage.createRejectMessage(new Chatroom(chatroomId),
+                            new Member(dto.getSenderId()),
+                            dto.getContent().getCancelMessage());
+                };
+        MatchingResponseChatMessage saved = this.chatMessageRepository.save(chatMessage);
+
+        this.matchingService.updateMatchingStatus(dto.getContent().getMatchingId(),
+                switch (dto.getContent().getMatchingResponseType()) {
+                    case ACCEPTED -> MatchingStatus.ACCEPTED;
+                    case REJECTED -> MatchingStatus.REJECTED;
+                });
+
+        return ChatMessageSendResponseDto.builder()
+                .chatMessageId(saved.getChatMessageId())
+                .chatroomId(chatroomId)
+                .senderId(dto.getSenderId())
+                .creationTime(saved.getCreationTime())
+                .lastModified(saved.getLastModified())
+                .content(Map.of(
+                        "matchingResponseType", dto.getContent().getMatchingResponseType().name(),
+                        "cancelMessage", dto.getContent().getCancelMessage() == null ? "" : dto.getContent().getCancelMessage()
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/TextChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/TextChatMessageProcessor.java
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
 import com.hf.healthfriend.domain.chat.dto.request.content.TextChatMessageSendRequestContent;
 import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
-import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.chat.entity.chatmessage.TextChatMessage;
 import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
-import com.hf.healthfriend.domain.member.entity.Member;
 
 import java.util.Map;
 
@@ -31,13 +29,7 @@ public class TextChatMessageProcessor extends AbstractChatMessageProcessorDelega
 
     @Override
     protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<TextChatMessageSendRequestContent> dto) {
-        TextChatMessage savedMessage = this.chatMessageRepository.save(
-                new TextChatMessage(
-                        new Chatroom(chatroomId),
-                        new Member(dto.getSenderId()),
-                        dto.getContent().getText()
-                )
-        );
+        TextChatMessage savedMessage = this.chatMessageRepository.saveMessageWithChatroomId(chatroomId, dto);
 
         return ChatMessageSendResponseDto.builder()
                 .chatMessageId(savedMessage.getChatMessageId())

--- a/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/TextChatMessageProcessor.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/service/delegator/TextChatMessageProcessor.java
@@ -1,0 +1,51 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.TextChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.TextChatMessage;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+
+import java.util.Map;
+
+public class TextChatMessageProcessor extends AbstractChatMessageProcessorDelegator<TextChatMessageSendRequestContent> {
+    private static TypeReference<ChatMessageSendRequestDto<TextChatMessageSendRequestContent>> DTO_TYPE =
+            new TypeReference<>() {
+            };
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    public TextChatMessageProcessor(ObjectMapper objectMapper, ChatMessageRepository chatMessageRepository) {
+        super(objectMapper);
+        this.chatMessageRepository = chatMessageRepository;
+    }
+
+    @Override
+    protected TypeReference<ChatMessageSendRequestDto<TextChatMessageSendRequestContent>> getTypeReference() {
+        return DTO_TYPE;
+    }
+
+    @Override
+    protected ChatMessageSendResponseDto processSendingMessage(Long chatroomId, ChatMessageSendRequestDto<TextChatMessageSendRequestContent> dto) {
+        TextChatMessage savedMessage = this.chatMessageRepository.save(
+                new TextChatMessage(
+                        new Chatroom(chatroomId),
+                        new Member(dto.getSenderId()),
+                        dto.getContent().getText()
+                )
+        );
+
+        return ChatMessageSendResponseDto.builder()
+                .chatMessageId(savedMessage.getChatMessageId())
+                .chatroomId(chatroomId)
+                .senderId(dto.getSenderId())
+                .creationTime(savedMessage.getCreationTime())
+                .lastModified(savedMessage.getLastModified())
+                .content(Map.of("text", dto.getContent().getText()))
+                .build();
+    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/chat/util/ChatMessageDtoConverter.java
+++ b/src/main/java/com/hf/healthfriend/domain/chat/util/ChatMessageDtoConverter.java
@@ -1,0 +1,15 @@
+package com.hf.healthfriend.domain.chat.util;
+
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+
+/**
+ * 채팅 메시지 요청 DTO를 Entity로 변경하는 Converter
+ */
+public class ChatMessageDtoConverter {
+
+//    public static <T> T toEntity(ChatMessageSendRequestDto requestDto, Class<? extends T> contentClass) {
+//        switch (requestDto.getChatMessageType()) {
+//            case TEXT ->
+//        }
+//    }
+}

--- a/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/entity/Member.java
@@ -134,7 +134,7 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipation> chatParticipations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessage> chatMessages = new ArrayList<>();
 
     @Column(name = "review_score")

--- a/src/main/java/com/hf/healthfriend/global/config/websocket/SimpleBrokerWebSocketConfig.java
+++ b/src/main/java/com/hf/healthfriend/global/config/websocket/SimpleBrokerWebSocketConfig.java
@@ -13,18 +13,18 @@ public class SimpleBrokerWebSocketConfig implements WebSocketMessageBrokerConfig
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/hf")
+        registry.addEndpoint("/hf/portfolio")
                 .setHandshakeHandler(new CustomWebSocketHandshakeHandler())
                 .withSockJS();
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes("/app");
+        registry.setApplicationDestinationPrefixes("/hf/app");
 
         // 내장 메시지 브로커
-        registry.enableSimpleBroker("/topic", "/queue", "/user");
+        registry.enableSimpleBroker("/hf/topic", "/hf/queue", "/hf/user");
 
-        registry.setUserDestinationPrefix("/user");
+        registry.setUserDestinationPrefix("/hf/user");
     }
 }

--- a/src/main/java/com/hf/healthfriend/global/websocket/CustomWebSocketHandshakeHandler.java
+++ b/src/main/java/com/hf/healthfriend/global/websocket/CustomWebSocketHandshakeHandler.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.global.websocket;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.socket.WebSocketHandler;
@@ -9,14 +10,15 @@ import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 import java.security.Principal;
 import java.util.Map;
 
+@Slf4j
 public class CustomWebSocketHandshakeHandler extends DefaultHandshakeHandler {
 
     @Override
     protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
         ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
         HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
-        String memberId = httpServletRequest.getParameter("memberId");
-
+        String memberId = httpServletRequest.getParameter("member-id");
+        log.debug("connected memberId: {}", memberId);
         return new CustomPrincipal(memberId);
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/chat/controller/TestChatMessagingController.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/controller/TestChatMessagingController.java
@@ -126,8 +126,28 @@ class TestChatMessagingController {
         this.memberRepository.delete(this.receiver);
     }
 
+    // 채팅 신청에 대한 응답, 채팅 메시지 전송에 대한 응답이 제대로 도착했는지 확인하기 위한 카운트다운
     CountDownLatch latch = new CountDownLatch(3);
 
+    /**
+     * <p>채팅 신청 및 채팅 메시지 전송 테스트
+     * <p>흐름은 다음과 같다.
+     * <p>1. 채팅에 참여하는 회원 (sender, receiver)는 미리 데이터베이스에 레코드 추가해 둠
+     * <p>2. 채팅 신청 메시지 전송 -> 채팅 신청 시 Chatroom 엔티티와 ChatParticipation 엔티티 생성됨
+     * <p>2.1. 채팅 신청 엔드포인트: /hf/app/chat/request
+     * <p>2.2. 채팅 신청 subscription 엔드포인트: /hf/user/chat/request
+     * <p>2.3. ChatMessagingController.requestChat() 메소드에서 처리
+     * <p>2.4. sender, receiver에게 각각 메시지 전송
+     * <p>3. 채팅 신청 완료 후 채팅 전송 - 아래 messageSendTest() 메소드
+     * <p>4. sender와 receiver 각각 채팅 메시지 엔드포인트 subscription
+     * <p>4.1. 채팅 메시지 전송 엔드포인트: /hf/app/chat/messages/{chatroomId}
+     * <p>4.2. 채팅 메시지 subscription 엔드포인트: /hf/topic/chat/messages/{chatroomId}
+     * <p>채팅 신청 응답 수신 시 한 번, 채팅 메시지 응답 수신 시 두 번 (sender와 receiver 각각 한 번)
+     * 총 세 번 CountDownLatch의 count가 하나씩 줄어듦
+     * <p>웹소켓 통신이 비동기 방식으로 처리되기 때문에 콜백 메소드 안에서 통신 처리 로직을 정의해야 하기
+     * 때문에 웹소켓 응답 결과를 return할 수 없음. 그래서 결과값을 ConcurrentHashMap에 저장. 이후
+     * ConcurrentHashMap에 담긴 값 검증
+     */
     @Test
     @DisplayName("채팅 신청 후 메시지 보내기 테스트 - 성공")
     void chatRequestAndThenSendMessage() throws InterruptedException {
@@ -137,6 +157,8 @@ class TestChatMessagingController {
         // 비동기 처리 상황에서 결과값을 검증할 객체를 담기 위한 ConcurrentHashMap
         Map<String, Object> resultMap = new ConcurrentHashMap<>();
 
+        // 채팅 신청 엔드포인트에 대한 subscription
+        // 신청자와 피신청자 둘 다 메시지를 받게 되지만, 우선 신청자만 구독
         this.senderSession.subscribe("/hf/user/" + this.sender.getId() + "/chat/request", new StompFrameHandler() {
 
             @Override
@@ -151,16 +173,20 @@ class TestChatMessagingController {
 
                 ChatParticipationResponseDto dto = (ChatParticipationResponseDto) payload;
                 resultMap.put("ChatParticipationResponseDto", dto);
-                messageSendTest(dto, resultMap); // 동기화했기 때문에 이 메소드가 끝날 때까지 대기함
+
+                // 채팅 신청 완료 후, 채팅 전송 테스트를 수행하는 메소드 호출
+                messageSendTest(dto, resultMap);
                 latch.countDown();
             }
         });
 
+        // 채팅 신청 메시지 전송
         this.senderSession.send("/hf/app/chat/request", Map.of(
                 "requesterId", this.sender.getId(),
                 "chatTargetId", this.receiver.getId()
         ));
 
+        // 비동기 처리가 모두 끝날 때까지 대기
         boolean await = latch.await(8, TimeUnit.SECONDS);
         log.info("count={}", latch.getCount());
 

--- a/src/test/java/com/hf/healthfriend/domain/chat/controller/TestChatMessagingController.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/controller/TestChatMessagingController.java
@@ -1,0 +1,245 @@
+package com.hf.healthfriend.domain.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hf.healthfriend.domain.chat.constant.ChatMessageType;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatParticipationResponseDto;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
+import com.hf.healthfriend.testutil.RedisTestConfig;
+import com.hf.healthfriend.testutil.SampleEntityGenerator;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({MysqlTestcontainerConfig.class, RedisTestConfig.class})
+@Slf4j
+class TestChatMessagingController {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChatParticipationRepository chatParticipationRepository;
+
+    @Autowired
+    ChatroomRepository chatroomRepository;
+
+    @Autowired
+    ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    PlatformTransactionManager txManager;
+
+    @LocalServerPort
+    int port;
+
+    StompSession senderSession;
+    StompSession receiverSession;
+    Member sender;
+    Member receiver;
+
+    @BeforeEach
+    void beforeEach() throws ExecutionException, InterruptedException {
+        // 채팅에 참여할 두 Member 엔티티 생성 및 데이터베이스에 삽입
+        // 여기서 저장된 sender와 receiver 엔티티를 다른 트랜잭션에서 사용해야 하므로
+        // 데이터베이스에 커밋 (afterEach에서 삭제)
+        TransactionStatus status = this.txManager.getTransaction(new DefaultTransactionAttribute());
+        this.sender = SampleEntityGenerator.generateSampleMember("sender@gmail.com", "sender");
+        this.receiver = SampleEntityGenerator.generateSampleMember("receiver@gmail.com", "receiver");
+        this.memberRepository.save(this.sender);
+        this.memberRepository.save(this.receiver);
+        this.txManager.commit(status);
+
+        // 웹 소켓 테스트를 위한 Client 생성
+        WebSocketStompClient senderClient = generateStompClient();
+        WebSocketStompClient receiverClient = generateStompClient();
+
+        // 웹 소켓 handshake
+        String websocketUrl = "ws://localhost:" + this.port + "/hf/portfolio";
+
+        // 웹 소켓 통신을 위한 SessionHandler 생성
+        StompSessionHandler stompSessionHandler = new StompSessionHandlerAdapter() {
+
+            @Override
+            public void afterConnected(StompSession session, @NotNull StompHeaders connectedHeaders) {
+                log.info("sessionId={}", session.getSessionId());
+                log.info("connectedHeaders={}", connectedHeaders);
+            }
+        };
+
+        // 웹 소켓 통신을 위한 Session 생성
+        this.senderSession = senderClient.connectAsync(websocketUrl + "?member-id=" + this.sender.getId(), stompSessionHandler).get();
+        this.receiverSession = receiverClient.connectAsync(websocketUrl + "?member-id=" + this.receiver.getId(), stompSessionHandler).get();
+    }
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private WebSocketStompClient generateStompClient() {
+        // SockJS 기반 웹 소켓 클라이언트 생성
+        WebSocketClient webSocketClient = new SockJsClient(List.of(
+                new WebSocketTransport(new StandardWebSocketClient())
+        ));
+        WebSocketStompClient stompClient = new WebSocketStompClient(webSocketClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter(this.objectMapper));
+        return stompClient;
+    }
+
+    @AfterEach
+    void afterEach() {
+        // sender와 receiver는 beforeEach에서 별도의 트랜잭션에서 생성되었기 때문에
+        // 직접 삭제
+        this.memberRepository.delete(this.sender);
+        this.memberRepository.delete(this.receiver);
+    }
+
+    CountDownLatch latch = new CountDownLatch(3);
+
+    @Test
+    @DisplayName("채팅 신청 후 메시지 보내기 테스트 - 성공")
+    void chatRequestAndThenSendMessage() throws InterruptedException {
+        // 새로운 트랜잭션에서 생성
+        TransactionStatus txStatus = this.txManager.getTransaction(new DefaultTransactionAttribute());
+
+        // 비동기 처리 상황에서 결과값을 검증할 객체를 담기 위한 ConcurrentHashMap
+        Map<String, Object> resultMap = new ConcurrentHashMap<>();
+
+        this.senderSession.subscribe("/hf/user/" + this.sender.getId() + "/chat/request", new StompFrameHandler() {
+
+            @Override
+            public @NotNull Type getPayloadType(@NotNull StompHeaders headers) {
+                return ChatParticipationResponseDto.class;
+            }
+
+            @Override
+            public void handleFrame(@NotNull StompHeaders headers, Object payload) {
+                log.info("payload={}", payload);
+                log.info("payload type: {}", payload.getClass());
+
+                ChatParticipationResponseDto dto = (ChatParticipationResponseDto) payload;
+                resultMap.put("ChatParticipationResponseDto", dto);
+                messageSendTest(dto, resultMap); // 동기화했기 때문에 이 메소드가 끝날 때까지 대기함
+                latch.countDown();
+            }
+        });
+
+        this.senderSession.send("/hf/app/chat/request", Map.of(
+                "requesterId", this.sender.getId(),
+                "chatTargetId", this.receiver.getId()
+        ));
+
+        boolean await = latch.await(8, TimeUnit.SECONDS);
+        log.info("count={}", latch.getCount());
+
+        // Then
+        assertThat(await).isTrue();
+
+        // 채팅 신청 검증
+        assertThat(this.chatParticipationRepository.findAll()).size().isEqualTo(2);
+
+        ChatParticipationResponseDto chatParticipationResponseDto =
+                (ChatParticipationResponseDto) resultMap.get("ChatParticipationResponseDto");
+        assertThat(chatParticipationResponseDto.newChatroomId()).isNotNull();
+        assertThat(chatParticipationResponseDto.creatorId()).isEqualTo(sender.getId());
+        assertThat(chatParticipationResponseDto.participantIds()).containsExactlyInAnyOrder(sender.getId(), receiver.getId());
+
+        // 채팅 메시지 전송 검증
+        assertThat(this.chatMessageRepository.findAll()).size().isEqualTo(1);
+
+        Long chatroomId = (Long) resultMap.get("chatroomId");
+        String chatMessage = (String) resultMap.get("expectedChatMessage");
+
+        ChatMessageSendResponseDto chatMessageSendResponseToSender =
+                (ChatMessageSendResponseDto) resultMap.get(this.sender.getId() + "ChatMessageSendResponseDto");
+        assertThat(chatMessageSendResponseToSender.chatMessageId()).isNotNull();
+        assertThat(chatMessageSendResponseToSender.chatroomId()).isEqualTo(chatroomId);
+        assertThat(chatMessageSendResponseToSender.senderId()).isEqualTo(this.sender.getId());
+        assertThat(chatMessageSendResponseToSender.content()).isEqualTo(Map.of("text", chatMessage));
+
+        ChatMessageSendResponseDto chatMessageSendResponseToReceiver =
+                (ChatMessageSendResponseDto) resultMap.get(this.receiver.getId() + "ChatMessageSendResponseDto");
+        assertThat(chatMessageSendResponseToReceiver.chatMessageId()).isNotNull();
+        assertThat(chatMessageSendResponseToReceiver.chatroomId()).isEqualTo(chatroomId);
+        assertThat(chatMessageSendResponseToReceiver.senderId()).isEqualTo(this.sender.getId());
+        assertThat(chatMessageSendResponseToReceiver.content()).isEqualTo(Map.of("text", chatMessage));
+
+        this.txManager.rollback(txStatus);
+    }
+
+    // 위에서는 채팅 신청 테스트, 여기서는 메시지 전송 테스트
+    private void messageSendTest(ChatParticipationResponseDto chatParticipationInfo,
+                                 Map<String, Object> resultMap) {
+        final String chatMessage = "Hello, World!";
+
+        resultMap.put("expectedChatMessage", chatMessage);
+        resultMap.put("chatroomId", chatParticipationInfo.newChatroomId());
+
+        Long chatroomId = chatParticipationInfo.newChatroomId();
+
+        subscribeEach(this.senderSession, this.sender, chatroomId, resultMap);
+        subscribeEach(this.receiverSession, this.receiver, chatroomId, resultMap);
+
+        this.senderSession.send("/hf/app/chat/messages/" + chatroomId, Map.of(
+                "senderId", this.sender.getId(),
+                "chatMessageType", ChatMessageType.TEXT,
+                "content", Map.of(
+                        "text", chatMessage
+                )
+        ));
+    }
+
+    private void subscribeEach(StompSession session,
+                               Member member,
+                               Long chatroomId,
+                               Map<String, Object> resultMap) {
+        session.subscribe("/hf/topic/chat/messages/" + chatroomId, new StompFrameHandler() {
+
+            @Override
+            public @NotNull Type getPayloadType(@NotNull StompHeaders headers) {
+                return ChatMessageSendResponseDto.class;
+            }
+
+            @Override
+            public void handleFrame(@NotNull StompHeaders headers, Object payload) {
+                log.info("payload={}", payload);
+                log.info("payload type: {}", payload.getClass());
+                ChatMessageSendResponseDto result = (ChatMessageSendResponseDto) payload;
+                resultMap.put(member.getId() + "ChatMessageSendResponseDto", result);
+                latch.countDown();
+            }
+        });
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatMessageRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatMessageRepository.java
@@ -1,0 +1,69 @@
+package com.hf.healthfriend.domain.chat.repository;
+
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ImageChatMessage;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
+import com.hf.healthfriend.testutil.SampleEntityGenerator;
+import com.hf.healthfriend.testutil.TestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@DataJpaTest
+@Import({
+        TestConfig.class,
+        MysqlTestcontainerConfig.class
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Slf4j
+class TestChatMessageRepository {
+
+    @Autowired
+    ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    ChatroomRepository chatroomRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChatParticipationRepository chatParticipationRepository;
+
+    @Test
+    @DisplayName("save() - 이미지 메시지 저장 성공")
+    void saveImageMessage_success() {
+        // Given
+        Member sender = SampleEntityGenerator.generateSampleMember("sender@gmail.com", "sender");
+        Member receiver = SampleEntityGenerator.generateSampleMember("receiver@gmail.com", "receiver");
+        this.memberRepository.save(sender);
+        this.memberRepository.save(receiver);
+
+        Chatroom dummyChatroom = SampleEntityGenerator.generateSampleChatroom(sender, receiver);
+        this.chatroomRepository.save(dummyChatroom);
+
+        // When
+        ImageChatMessage message = new ImageChatMessage(dummyChatroom, sender, "http://localhost/image.jpg");
+        assertThatNoException().isThrownBy(() -> this.chatMessageRepository.save(message));
+
+        // Then
+        Optional<ChatMessage> findMessageOp = this.chatMessageRepository.findById(message.getChatMessageId());
+        assertThat(findMessageOp).isNotEmpty();
+        ChatMessage chatMessage = findMessageOp.get();
+        assertThat(chatMessage instanceof ImageChatMessage).isTrue();
+        assertThat(((ImageChatMessage) chatMessage).getImageUrl()).isEqualTo(message.getImageUrl());
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatroomRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/repository/TestChatroomRepository.java
@@ -1,6 +1,7 @@
 package com.hf.healthfriend.domain.chat.repository;
 
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
+import com.hf.healthfriend.domain.chat.entity.ChatParticipationId;
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,22 +49,18 @@ class TestChatroomRepository {
         this.memberRepository.save(target);
 
         // When
-        Chatroom chatroom = new Chatroom();
-        ChatParticipation reqPart = new ChatParticipation(chatroom, requester);
-        ChatParticipation tarPart = new ChatParticipation(chatroom, target);
+        Chatroom chatroom = Chatroom.newChatroom(requester, target);
         this.chatroomRepository.save(chatroom);
 
         // Then
         Optional<Chatroom> chatroomOp = this.chatroomRepository.findById(chatroom.getChatroomId());
         assertThat(chatroomOp).isNotEmpty();
-        assertThat(this.chatParticipationRepository.findById(reqPart.getChatParticipationId()))
-                .isNotEmpty();
-        assertThat(this.chatParticipationRepository.findById(tarPart.getChatParticipationId()))
-                .isNotEmpty();
+        List<ChatParticipation> findParticipations = this.chatParticipationRepository.findAll();
+        assertThat(findParticipations).size().isEqualTo(2);
 
         Chatroom findChatroom = chatroomOp.get();
 
         assertThat(findChatroom.getParticipations().stream().map(ChatParticipation::getChatParticipationId))
-                .containsExactlyInAnyOrder(reqPart.getChatParticipationId(), tarPart.getChatParticipationId());
+                .containsExactlyInAnyOrder(findParticipations.stream().map(ChatParticipation::getChatParticipationId).toArray(ChatParticipationId[]::new));
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/chat/repository/custom/TestChatMessageCustomRepositoryImpl.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/repository/custom/TestChatMessageCustomRepositoryImpl.java
@@ -1,0 +1,137 @@
+package com.hf.healthfriend.domain.chat.repository.custom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hf.healthfriend.domain.chat.constant.ChatMessageType;
+import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.request.content.ImageChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingRequestChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.MatchingResponseChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.dto.request.content.TextChatMessageSendRequestContent;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.ChatMessage;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
+import com.hf.healthfriend.testutil.SampleEntityGenerator;
+import com.hf.healthfriend.testutil.TestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({
+        TestConfig.class,
+        MysqlTestcontainerConfig.class
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Slf4j
+class TestChatMessageCustomRepositoryImpl {
+
+    @Autowired
+    ChatMessageCustomRepositoryImpl chatMessageCustomRepository;
+
+    @Autowired
+    ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    ChatroomRepository chatroomRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChatParticipationRepository chatParticipationRepository;
+
+    static Stream<Arguments> saveMessageWithChatroomId_success() {
+        return Stream.of(
+                Arguments.of("텍스트 채팅 메시지", ChatMessageType.TEXT, Map.of("text", "Hello!")),
+                Arguments.of(
+                        "매칭 신청 채팅 메시지",
+                        ChatMessageType.MATCHING_REQUEST,
+                        Map.of(
+                                "matchingTargetId", 0L,
+                                "meetingTime", LocalDateTime.now().plusDays(1),
+                                "meetingPlace", "Somewhere",
+                                "meetingPlaceAddress", "Somewhere"
+                        )
+                ),
+                Arguments.of(
+                        "매칭 수락 채팅 메시지",
+                        ChatMessageType.MATCHING_RESPONSE,
+                        Map.of(
+                                "matchingResponseType", MatchingResponseType.ACCEPTED,
+                                "matchingId", 0L,
+                                "cancelMessage", ""
+                        )
+                ),
+                Arguments.of(
+                        "매칭 거절 채팅 메시지",
+                        ChatMessageType.MATCHING_RESPONSE,
+                        Map.of(
+                                "matchingResponseType", MatchingResponseType.REJECTED,
+                                "matchingId", 0L,
+                                "cancelMessage", "No"
+                        )
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("save() - {0} - 저장 성공")
+    void saveMessageWithChatroomId_success(String testCaseName, ChatMessageType chatMessageType, Map<String, Object> content) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        // Given
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Member sender = SampleEntityGenerator.generateSampleMember("sender@gmail.com", "sender");
+        Member receiver = SampleEntityGenerator.generateSampleMember("receiver@gmail.com", "receiver");
+        this.memberRepository.save(sender);
+        this.memberRepository.save(receiver);
+
+        Chatroom dummyChatroom = SampleEntityGenerator.generateSampleChatroom(sender, receiver);
+        this.chatroomRepository.save(dummyChatroom);
+
+        Constructor<ChatMessageSendRequestDto> constructor = ChatMessageSendRequestDto.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        ChatMessageSendRequestDto<?> dto = constructor.newInstance();
+        ReflectionTestUtils.setField(dto, "senderId", sender.getId());
+        ReflectionTestUtils.setField(dto, "chatMessageType", chatMessageType);
+        ReflectionTestUtils.setField(dto, "content",
+                switch (chatMessageType) {
+                    case TEXT -> objectMapper.convertValue(content, TextChatMessageSendRequestContent.class);
+                    case IMAGE -> objectMapper.convertValue(content, ImageChatMessageSendRequestContent.class);
+                    case MATCHING_REQUEST -> objectMapper.convertValue(content, MatchingRequestChatMessageSendRequestContent.class);
+                    case MATCHING_RESPONSE -> objectMapper.convertValue(content, MatchingResponseChatMessageSendRequestContent.class);
+                }
+        );
+
+        // When
+        ChatMessage message = this.chatMessageCustomRepository.saveMessageWithChatroomId(dummyChatroom.getChatroomId(), dto);
+
+        // Then
+        Optional<ChatMessage> findMessageOp = this.chatMessageRepository.findById(message.getChatMessageId());
+        assertThat(findMessageOp).isNotEmpty();
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/chat/repository/custom/TestChatroomCustomRepositoryImpl.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/repository/custom/TestChatroomCustomRepositoryImpl.java
@@ -1,13 +1,16 @@
-package com.hf.healthfriend.domain.chat.repository;
+package com.hf.healthfriend.domain.chat.repository.custom;
 
 import com.hf.healthfriend.domain.chat.entity.ChatParticipation;
 import com.hf.healthfriend.domain.chat.entity.ChatParticipationId;
 import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.repository.ChatParticipationRepository;
+import com.hf.healthfriend.domain.chat.repository.ChatroomRepository;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
 import com.hf.healthfriend.testutil.SampleEntityGenerator;
 import com.hf.healthfriend.testutil.TestConfig;
+import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Slf4j
-class TestChatroomRepository {
+class TestChatroomCustomRepositoryImpl {
+
+    @Autowired
+    ChatroomCustomRepositoryImpl chatroomCustomRepository;
 
     @Autowired
     ChatroomRepository chatroomRepository;
@@ -39,18 +45,25 @@ class TestChatroomRepository {
     @Autowired
     ChatParticipationRepository chatParticipationRepository;
 
+    @Autowired
+    EntityManager em;
+
     @Test
-    @DisplayName("save() - 채팅방 생성 시 Cascade 설정에 따라 ChatParticipation도 생성")
-    void save_checkCascade_success() {
+    @DisplayName("saveWithParticipants() - success")
+    void saveWithParticipants_success() {
         // Given
         Member requester = SampleEntityGenerator.generateSampleMember("requester@gmail.com", "REQ");
         Member target = SampleEntityGenerator.generateSampleMember("target@gmail.com", "TAR");
         this.memberRepository.save(requester);
         this.memberRepository.save(target);
 
+        this.em.detach(requester);
+        this.em.detach(target);
+
         // When
-        Chatroom chatroom = Chatroom.newChatroom(requester, target);
-        this.chatroomRepository.save(chatroom);
+        Chatroom chatroom =
+                this.chatroomCustomRepository.saveWithParticipants(new Member(requester.getId()),
+                        new Member(target.getId()));
 
         // Then
         Optional<Chatroom> chatroomOp = this.chatroomRepository.findById(chatroom.getChatroomId());

--- a/src/test/java/com/hf/healthfriend/domain/chat/service/TestChatService.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/service/TestChatService.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,11 +53,10 @@ class TestChatService {
         ReflectionTestUtils.setField(sampleReceiver, "id", receiverId);
 
         Chatroom mockReturnChatroom = new Chatroom(chatroomId);
-        ReflectionTestUtils.setField(mockReturnChatroom, "lastChatMessageId", 1000L);
         ReflectionTestUtils.setField(mockReturnChatroom, "participations", List.of(sampleRequester, sampleReceiver));
 
-        when(this.chatroomRepository.save(any()))
-                .thenReturn(mockReturnChatroom);
+        doReturn(mockReturnChatroom).when(this.chatroomRepository)
+                .saveWithParticipants(any(), any());
 
         // When
         Constructor<ChatParticipationRequestDto> constructor = ChatParticipationRequestDto.class.getDeclaredConstructor();

--- a/src/test/java/com/hf/healthfriend/domain/chat/service/delegator/TestDelegatingChatMessageProcessorBean.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/service/delegator/TestDelegatingChatMessageProcessorBean.java
@@ -1,0 +1,267 @@
+package com.hf.healthfriend.domain.chat.service.delegator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hf.healthfriend.domain.chat.constant.ChatMessageType;
+import com.hf.healthfriend.domain.chat.constant.MatchingResponseType;
+import com.hf.healthfriend.domain.chat.dto.request.ChatMessageSendRequestDto;
+import com.hf.healthfriend.domain.chat.dto.response.ChatMessageSendResponseDto;
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingRequestChatMessage;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.MatchingResponseChatMessage;
+import com.hf.healthfriend.domain.chat.entity.chatmessage.TextChatMessage;
+import com.hf.healthfriend.domain.chat.repository.ChatMessageRepository;
+import com.hf.healthfriend.domain.matching.service.MatchingService;
+import com.hf.healthfriend.domain.member.entity.Member;
+import com.hf.healthfriend.global.file.FileUrlResolver;
+import com.hf.healthfriend.global.file.image.ImageExtension;
+import com.hf.healthfriend.global.jackson.deserializer.ImageExtensionDeserializer;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class TestDelegatingChatMessageProcessorBean {
+    private static final Long DUMMY_CHATROOM_ID = 1000L;
+    private static final Long DUMMY_SENDER_ID = 2000L;
+    private static final Long DUMMY_MATCHING_ID = 3000L;
+    private static final Long DUMMY_CHAT_MESSAGE_ID = 4000L;
+    private static final Map<String, Object> DUMMY_MATCHING_REQUEST_DATA = Map.of(
+            "matchingTargetId", 5000L,
+            "meetingTime", LocalDateTime.now().plusDays(1),
+            "meetingPlace", "PLACE",
+            "meetingPlaceAddress", "ADDRESS"
+    );
+    private static final String DUMMY_CHAT_MESSAGE = "Hello, World!";
+
+    @TestConfiguration
+    @ComponentScan(basePackages = "com.hf.healthfriend.domain.chat.service.delegator")
+    static class TestDelegatingChatMessageProcessorBeanConfig {
+
+        @Bean
+        public ObjectMapper objectMapper() {
+            ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            objectMapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+
+            SimpleModule imageExtensionModule = new SimpleModule();
+            imageExtensionModule.addDeserializer(ImageExtension.class, new ImageExtensionDeserializer());
+            objectMapper.registerModule(imageExtensionModule);
+
+            return objectMapper;
+        }
+
+        @Bean
+        public FileUrlResolver fileUrlResolver() {
+            return Mockito.mock(FileUrlResolver.class);
+        }
+
+        @Bean
+        public ChatMessageRepository chatMessageRepository() {
+            ChatMessageRepository chatMessageRepositoryMock = Mockito.mock(ChatMessageRepository.class);
+
+            LocalDateTime now = LocalDateTime.now();
+
+            TextChatMessage textChatMessage = new TextChatMessage(
+                    new Chatroom(DUMMY_CHATROOM_ID),
+                    new Member(DUMMY_SENDER_ID),
+                    DUMMY_CHAT_MESSAGE
+            );
+
+            setCommonChatMessageField(textChatMessage, now);
+
+            doReturn(textChatMessage).when(chatMessageRepositoryMock).save(isA(TextChatMessage.class));
+
+            MatchingRequestChatMessage matchingRequestChatMessage = new MatchingRequestChatMessage(
+                    new Chatroom(DUMMY_CHATROOM_ID),
+                    new Member(DUMMY_SENDER_ID),
+                    (LocalDateTime) DUMMY_MATCHING_REQUEST_DATA.get("meetingTime"),
+                    (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlace"),
+                    (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlaceAddress")
+            );
+
+            setCommonChatMessageField(matchingRequestChatMessage, now);
+
+            doReturn(matchingRequestChatMessage)
+                    .when(chatMessageRepositoryMock).save(isA(MatchingRequestChatMessage.class));
+
+            MatchingResponseChatMessage acceptMatchingResponseChatMessage =
+                    MatchingResponseChatMessage.createAcceptanceMessage(new Chatroom(DUMMY_CHATROOM_ID), new Member(DUMMY_SENDER_ID));
+
+            setCommonChatMessageField(acceptMatchingResponseChatMessage, now);
+
+            doReturn(acceptMatchingResponseChatMessage)
+                    .when(chatMessageRepositoryMock)
+                    .save(argThat(new MatchingResponseChatMessageArgumentMatcher(acceptMatchingResponseChatMessage)));
+
+            MatchingResponseChatMessage rejectMatchingResponseChatMessage =
+                    MatchingResponseChatMessage.createRejectMessage(new Chatroom(DUMMY_CHATROOM_ID),
+                            new Member(DUMMY_SENDER_ID),
+                            DUMMY_CHAT_MESSAGE);
+
+            setCommonChatMessageField(rejectMatchingResponseChatMessage, now);
+
+            doReturn(rejectMatchingResponseChatMessage)
+                    .when(chatMessageRepositoryMock)
+                    .save(argThat(new MatchingResponseChatMessageArgumentMatcher(rejectMatchingResponseChatMessage)));
+
+            return chatMessageRepositoryMock;
+        }
+
+        @RequiredArgsConstructor
+        static class MatchingResponseChatMessageArgumentMatcher implements ArgumentMatcher<MatchingResponseChatMessage> {
+            private final MatchingResponseChatMessage thisMessage;
+
+            @Override
+            public boolean matches(MatchingResponseChatMessage argument) {
+                return thisMessage.getMatchingResponseType() == argument.getMatchingResponseType();
+            }
+        }
+
+        private void setCommonChatMessageField(Object toSet, LocalDateTime now) {
+            ReflectionTestUtils.setField(toSet, "creationTime", now);
+            ReflectionTestUtils.setField(toSet, "lastModified", now);
+            ReflectionTestUtils.setField(toSet, "chatMessageId", DUMMY_CHAT_MESSAGE_ID);
+        }
+
+        @Bean
+        public MatchingService matchingService() {
+            MatchingService matchingServiceMock = Mockito.mock(MatchingService.class);
+
+            when(matchingServiceMock.requestMatching(any())).thenReturn(DUMMY_MATCHING_ID);
+
+            return matchingServiceMock;
+        }
+    }
+
+    @Autowired
+    DelegatingChatMessageProcessorBean processor;
+
+    @Test
+    @DisplayName("sendMessage() - 텍스트 메시지 처리 성공")
+    void sendMessage_textMessage_success() throws Exception {
+        // Given
+        Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
+        dtoConstructor.setAccessible(true);
+        Object dtoInstance = dtoConstructor.newInstance();
+        ReflectionTestUtils.setField(dtoInstance, "senderId", DUMMY_SENDER_ID);
+        ReflectionTestUtils.setField(dtoInstance, "chatMessageType", ChatMessageType.TEXT);
+        ReflectionTestUtils.setField(dtoInstance, "content", Map.of("text", DUMMY_CHAT_MESSAGE));
+
+        // When
+        ChatMessageSendResponseDto result = this.processor.sendMessage(DUMMY_CHATROOM_ID, (ChatMessageSendRequestDto<Object>) dtoInstance);
+
+        // Then
+        assertThat(result.chatMessageId()).isEqualTo(DUMMY_CHAT_MESSAGE_ID);
+        assertThat(result.chatroomId()).isEqualTo(DUMMY_CHATROOM_ID);
+        assertThat(result.senderId()).isEqualTo(DUMMY_SENDER_ID);
+        assertThat(result.content()).isEqualTo(Map.of("text", DUMMY_CHAT_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("sendMessage() - 매칭 신청 메시지 전송 성공")
+    void sendMessage_matchingRequest_success() throws Exception {
+        // Given
+        Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
+        dtoConstructor.setAccessible(true);
+        Object dtoInstance = dtoConstructor.newInstance();
+        ReflectionTestUtils.setField(dtoInstance, "senderId", DUMMY_SENDER_ID);
+        ReflectionTestUtils.setField(dtoInstance, "chatMessageType", ChatMessageType.MATCHING_REQUEST);
+        ReflectionTestUtils.setField(dtoInstance, "content", DUMMY_MATCHING_REQUEST_DATA);
+
+        // When
+        ChatMessageSendResponseDto result = this.processor.sendMessage(DUMMY_CHATROOM_ID, (ChatMessageSendRequestDto<Object>) dtoInstance);
+
+        // Then
+        assertThat(result.chatMessageId()).isEqualTo(DUMMY_CHAT_MESSAGE_ID);
+        assertThat(result.chatroomId()).isEqualTo(DUMMY_CHATROOM_ID);
+        assertThat(result.senderId()).isEqualTo(DUMMY_SENDER_ID);
+        assertThat(result.content()).isEqualTo(
+                Map.of(
+                        "matchingId", DUMMY_MATCHING_ID,
+                        "meetingTime", DUMMY_MATCHING_REQUEST_DATA.get("meetingTime"),
+                        "meetingPlace", DUMMY_MATCHING_REQUEST_DATA.get("meetingPlace"),
+                        "meetingPlaceAddress", DUMMY_MATCHING_REQUEST_DATA.get("meetingPlaceAddress")
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("sendMessage() - 매칭 수락 응답 메시지 전송 성공")
+    void sendMessage_matchingResponse_accept_success() throws Exception {
+        // Given
+        Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
+        dtoConstructor.setAccessible(true);
+        Object dtoInstance = dtoConstructor.newInstance();
+        ReflectionTestUtils.setField(dtoInstance, "senderId", DUMMY_SENDER_ID);
+        ReflectionTestUtils.setField(dtoInstance, "chatMessageType", ChatMessageType.MATCHING_RESPONSE);
+        ReflectionTestUtils.setField(dtoInstance, "content", Map.of(
+                "matchingResponseType", MatchingResponseType.ACCEPTED.name(),
+                "matchingId", DUMMY_MATCHING_ID
+        ));
+
+        // When
+        ChatMessageSendResponseDto result = this.processor.sendMessage(DUMMY_CHATROOM_ID, (ChatMessageSendRequestDto<Object>) dtoInstance);
+
+        // Then
+        assertThat(result.chatMessageId()).isEqualTo(DUMMY_CHAT_MESSAGE_ID);
+        assertThat(result.chatroomId()).isEqualTo(DUMMY_CHATROOM_ID);
+        assertThat(result.senderId()).isEqualTo(DUMMY_SENDER_ID);
+        assertThat(result.content()).isEqualTo(
+                Map.of(
+                        "matchingResponseType", MatchingResponseType.ACCEPTED.name(),
+                        "cancelMessage", ""
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("sendMessage() - 매칭 거절 응답 메시지 전송 성공")
+    void sendMessage_matchingResponse_reject_success() throws Exception {
+        // Given
+        Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
+        dtoConstructor.setAccessible(true);
+        Object dtoInstance = dtoConstructor.newInstance();
+        ReflectionTestUtils.setField(dtoInstance, "senderId", DUMMY_SENDER_ID);
+        ReflectionTestUtils.setField(dtoInstance, "chatMessageType", ChatMessageType.MATCHING_RESPONSE);
+        ReflectionTestUtils.setField(dtoInstance, "content", Map.of(
+                "matchingResponseType", MatchingResponseType.REJECTED.name(),
+                "matchingId", DUMMY_MATCHING_ID,
+                "cancelMessage", DUMMY_CHAT_MESSAGE
+        ));
+
+        // When
+        ChatMessageSendResponseDto result = this.processor.sendMessage(DUMMY_CHATROOM_ID, (ChatMessageSendRequestDto<Object>) dtoInstance);
+
+        // Then
+        assertThat(result.chatMessageId()).isEqualTo(DUMMY_CHAT_MESSAGE_ID);
+        assertThat(result.chatroomId()).isEqualTo(DUMMY_CHATROOM_ID);
+        assertThat(result.senderId()).isEqualTo(DUMMY_SENDER_ID);
+        assertThat(result.content()).isEqualTo(
+                Map.of(
+                        "matchingResponseType", MatchingResponseType.REJECTED.name(),
+                        "cancelMessage", DUMMY_CHAT_MESSAGE
+                )
+        );
+    }
+}

--- a/src/test/java/com/hf/healthfriend/domain/chat/service/delegator/TestDelegatingChatMessageProcessorBean.java
+++ b/src/test/java/com/hf/healthfriend/domain/chat/service/delegator/TestDelegatingChatMessageProcessorBean.java
@@ -78,54 +78,7 @@ class TestDelegatingChatMessageProcessorBean {
 
         @Bean
         public ChatMessageRepository chatMessageRepository() {
-            ChatMessageRepository chatMessageRepositoryMock = Mockito.mock(ChatMessageRepository.class);
-
-            LocalDateTime now = LocalDateTime.now();
-
-            TextChatMessage textChatMessage = new TextChatMessage(
-                    new Chatroom(DUMMY_CHATROOM_ID),
-                    new Member(DUMMY_SENDER_ID),
-                    DUMMY_CHAT_MESSAGE
-            );
-
-            setCommonChatMessageField(textChatMessage, now);
-
-            doReturn(textChatMessage).when(chatMessageRepositoryMock).save(isA(TextChatMessage.class));
-
-            MatchingRequestChatMessage matchingRequestChatMessage = new MatchingRequestChatMessage(
-                    new Chatroom(DUMMY_CHATROOM_ID),
-                    new Member(DUMMY_SENDER_ID),
-                    (LocalDateTime) DUMMY_MATCHING_REQUEST_DATA.get("meetingTime"),
-                    (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlace"),
-                    (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlaceAddress")
-            );
-
-            setCommonChatMessageField(matchingRequestChatMessage, now);
-
-            doReturn(matchingRequestChatMessage)
-                    .when(chatMessageRepositoryMock).save(isA(MatchingRequestChatMessage.class));
-
-            MatchingResponseChatMessage acceptMatchingResponseChatMessage =
-                    MatchingResponseChatMessage.createAcceptanceMessage(new Chatroom(DUMMY_CHATROOM_ID), new Member(DUMMY_SENDER_ID));
-
-            setCommonChatMessageField(acceptMatchingResponseChatMessage, now);
-
-            doReturn(acceptMatchingResponseChatMessage)
-                    .when(chatMessageRepositoryMock)
-                    .save(argThat(new MatchingResponseChatMessageArgumentMatcher(acceptMatchingResponseChatMessage)));
-
-            MatchingResponseChatMessage rejectMatchingResponseChatMessage =
-                    MatchingResponseChatMessage.createRejectMessage(new Chatroom(DUMMY_CHATROOM_ID),
-                            new Member(DUMMY_SENDER_ID),
-                            DUMMY_CHAT_MESSAGE);
-
-            setCommonChatMessageField(rejectMatchingResponseChatMessage, now);
-
-            doReturn(rejectMatchingResponseChatMessage)
-                    .when(chatMessageRepositoryMock)
-                    .save(argThat(new MatchingResponseChatMessageArgumentMatcher(rejectMatchingResponseChatMessage)));
-
-            return chatMessageRepositoryMock;
+            return Mockito.mock(ChatMessageRepository.class);
         }
 
         @RequiredArgsConstructor
@@ -136,12 +89,6 @@ class TestDelegatingChatMessageProcessorBean {
             public boolean matches(MatchingResponseChatMessage argument) {
                 return thisMessage.getMatchingResponseType() == argument.getMatchingResponseType();
             }
-        }
-
-        private void setCommonChatMessageField(Object toSet, LocalDateTime now) {
-            ReflectionTestUtils.setField(toSet, "creationTime", now);
-            ReflectionTestUtils.setField(toSet, "lastModified", now);
-            ReflectionTestUtils.setField(toSet, "chatMessageId", DUMMY_CHAT_MESSAGE_ID);
         }
 
         @Bean
@@ -157,10 +104,23 @@ class TestDelegatingChatMessageProcessorBean {
     @Autowired
     DelegatingChatMessageProcessorBean processor;
 
+    @Autowired
+    ChatMessageRepository chatMessageRepositoryMock;
+
     @Test
     @DisplayName("sendMessage() - 텍스트 메시지 처리 성공")
     void sendMessage_textMessage_success() throws Exception {
         // Given
+        TextChatMessage textChatMessage = new TextChatMessage(
+                new Chatroom(DUMMY_CHATROOM_ID),
+                new Member(DUMMY_SENDER_ID),
+                DUMMY_CHAT_MESSAGE
+        );
+
+        setCommonChatMessageField(textChatMessage, LocalDateTime.now());
+
+        doReturn(textChatMessage).when(chatMessageRepositoryMock).saveMessageWithChatroomId(any(), any());
+
         Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
         dtoConstructor.setAccessible(true);
         Object dtoInstance = dtoConstructor.newInstance();
@@ -182,6 +142,19 @@ class TestDelegatingChatMessageProcessorBean {
     @DisplayName("sendMessage() - 매칭 신청 메시지 전송 성공")
     void sendMessage_matchingRequest_success() throws Exception {
         // Given
+        MatchingRequestChatMessage matchingRequestChatMessage = new MatchingRequestChatMessage(
+                new Chatroom(DUMMY_CHATROOM_ID),
+                new Member(DUMMY_SENDER_ID),
+                (LocalDateTime) DUMMY_MATCHING_REQUEST_DATA.get("meetingTime"),
+                (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlace"),
+                (String) DUMMY_MATCHING_REQUEST_DATA.get("meetingPlaceAddress")
+        );
+
+        setCommonChatMessageField(matchingRequestChatMessage, LocalDateTime.now());
+
+        doReturn(matchingRequestChatMessage)
+                .when(chatMessageRepositoryMock).saveMessageWithChatroomId(any(), any());
+
         Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
         dtoConstructor.setAccessible(true);
         Object dtoInstance = dtoConstructor.newInstance();
@@ -210,6 +183,15 @@ class TestDelegatingChatMessageProcessorBean {
     @DisplayName("sendMessage() - 매칭 수락 응답 메시지 전송 성공")
     void sendMessage_matchingResponse_accept_success() throws Exception {
         // Given
+        MatchingResponseChatMessage acceptMatchingResponseChatMessage =
+                MatchingResponseChatMessage.createAcceptanceMessage(new Chatroom(DUMMY_CHATROOM_ID), new Member(DUMMY_SENDER_ID));
+
+        setCommonChatMessageField(acceptMatchingResponseChatMessage, LocalDateTime.now());
+
+        doReturn(acceptMatchingResponseChatMessage)
+                .when(chatMessageRepositoryMock)
+                .saveMessageWithChatroomId(any(), any());
+
         Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
         dtoConstructor.setAccessible(true);
         Object dtoInstance = dtoConstructor.newInstance();
@@ -239,6 +221,17 @@ class TestDelegatingChatMessageProcessorBean {
     @DisplayName("sendMessage() - 매칭 거절 응답 메시지 전송 성공")
     void sendMessage_matchingResponse_reject_success() throws Exception {
         // Given
+        MatchingResponseChatMessage rejectMatchingResponseChatMessage =
+                MatchingResponseChatMessage.createRejectMessage(new Chatroom(DUMMY_CHATROOM_ID),
+                        new Member(DUMMY_SENDER_ID),
+                        DUMMY_CHAT_MESSAGE);
+
+        setCommonChatMessageField(rejectMatchingResponseChatMessage, LocalDateTime.now());
+
+        doReturn(rejectMatchingResponseChatMessage)
+                .when(chatMessageRepositoryMock)
+                .saveMessageWithChatroomId(any(), any());
+
         Constructor<?> dtoConstructor = ChatMessageSendRequestDto.class.getDeclaredConstructors()[0];
         dtoConstructor.setAccessible(true);
         Object dtoInstance = dtoConstructor.newInstance();
@@ -263,5 +256,11 @@ class TestDelegatingChatMessageProcessorBean {
                         "cancelMessage", DUMMY_CHAT_MESSAGE
                 )
         );
+    }
+
+    private void setCommonChatMessageField(Object toSet, LocalDateTime now) {
+        ReflectionTestUtils.setField(toSet, "creationTime", now);
+        ReflectionTestUtils.setField(toSet, "lastModified", now);
+        ReflectionTestUtils.setField(toSet, "chatMessageId", DUMMY_CHAT_MESSAGE_ID);
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/review/repository/TestReviewRepository.java
+++ b/src/test/java/com/hf/healthfriend/domain/review/repository/TestReviewRepository.java
@@ -9,6 +9,7 @@ import com.hf.healthfriend.domain.review.constants.EvaluationType;
 import com.hf.healthfriend.domain.review.entity.Review;
 import com.hf.healthfriend.domain.review.entity.ReviewEvaluation;
 import com.hf.healthfriend.domain.review.repository.dto.RevieweeStatisticsQueryResultDto;
+import com.hf.healthfriend.testutil.MysqlTestcontainerConfig;
 import com.hf.healthfriend.testutil.SampleEntityGenerator;
 import com.hf.healthfriend.testutil.TestConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -29,13 +30,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @DataJpaTest
-@ActiveProfiles({
-        "local-dev",
-        "secret",
-        "priv",
-        "constants"
+@Import({
+        TestConfig.class,
+        MysqlTestcontainerConfig.class
 })
-@Import(TestConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TestReviewRepository {
 

--- a/src/test/java/com/hf/healthfriend/testutil/SampleEntityGenerator.java
+++ b/src/test/java/com/hf/healthfriend/testutil/SampleEntityGenerator.java
@@ -1,5 +1,6 @@
 package com.hf.healthfriend.testutil;
 
+import com.hf.healthfriend.domain.chat.entity.Chatroom;
 import com.hf.healthfriend.domain.matching.entity.Matching;
 import com.hf.healthfriend.domain.member.constant.*;
 import com.hf.healthfriend.domain.member.entity.Member;
@@ -95,5 +96,9 @@ public class SampleEntityGenerator {
                 new ReviewEvaluation(EvaluationType.NOT_GOOD, 1),
                 new ReviewEvaluation(EvaluationType.NOT_GOOD, 2)
         );
+    }
+
+    public static Chatroom generateSampleChatroom(Member... participants) {
+        return Chatroom.newChatroom(participants);
     }
 }


### PR DESCRIPTION
# 이슈 번호
#136 

## 개요
- 채팅 신청 endpoint 구현
- 채팅 메시지 전송 및 저장 비즈니스 로직 구현
- 채팅 메시지 전송 endpoint 구현

## 추가사항
PR #148 의 커밋을 포함하고 있으므로 PR #148 이 머지된 이후 리뷰해 주시면 되겠습니다

그리고 코드의 양이 상당히 많습니다... 죄송합니다... 아래에 설명을 첨부하므로 참고하시고 코드의 흐름만 봐 주시면 감사하겠습니다!

# 설명
클라이언트에서 채팅 메시지를 전송하려면 채팅 메시지 포맷에 맞게 채팅 메시지를 ```/hf/app/chat/messages/{chatroomId}```에 전송해야 한다. 이때 채팅 메시지 타입이 여러 가지 있기 때문에 각 타입에 따라 채팅 메시지를 따로 다루어야 한다.

## 채팅 신청 흐름
채팅 신청 흐름은 간단하다. 채팅을 신청하고자 하는 클라이언트가 ```/hf/app/chat/request```로 채팅 신청 요청을 보내면 서버에서는 채팅 신청과 관련된 비즈니스 로직을 수행하고 ```Chatroom```과 ```ChatParticipation``` 엔티티를 생성해 DB에 저장한다. 그리고 채팅 신청자와 채팅 신청 대상자에게 웹 소켓을 통해 결과를 전송한다.

## 채팅 전송

### Chat Message Content
ChatMessageContent 계열 DTO를 따로 정의한 이유는, 각 메시지 타입에 따라 채팅 메시지 내용이 달라지기 때문이다. 이 DTO 클래스들은 ```com.hf.healthfriend.domain.chat.dto.request.content``` 패키지에 들어 있다.

- ```ImageChatMessageSendRequestContent```: 이미지 채팅 메시지 내용을 담고 있는 DTO 객체
  - ```imageExtension```: 이미지의 확장자
- ```MatchingRequestChatMessageSendRequestContent```: 매칭 신청을 보내는 메시지의 내용을 담고 있는 DTO 객체
  - ```matchingTargetId```: 매칭 대상 회원의 ID
  - ```meetingTime```: 만나서 운동하고자 하는 시간
  - ```meetingPlace```: 운동하고자 하는 장소
  - ```meetingPlaceAddress```: 운동하고자 하는 장소의 주소
- ```MatchingResponseChatMessageSendRequestContent```: 매칭 신청에 대한 응답을 보낼 때 메시지 내용을 담고 있는 DTO 객체
  - ```matchingResponseType```: 매칭을 수락할 것인지 거절할 것인지 정보를 가진 enum
  - ```matchingId```: 응답하고자 하는 매칭의 ID
  - ```cancelMessage```: 매칭 거절 시 거절 메시지. 매칭 수락일 경우 null
- ```TextChatMessageSendRequestContent```: 일반 텍스트 메시지
  - ```text```: 텍스트 메시지 내용

위의 ChatMessageContent 객체는 ```ChatMessageSendRequestDto```의 ```content```필드에 담긴다.

### 채팅 전송 흐름
클라이언트에서 채팅 메시지를 전송하고 ```@MessageMapping```으로 정의된 컨트롤러의 엔드포인트에 요청이 도달하면, 다음과 같은 흐름으로 요청이 처리된다.
![Entity Relationship Diagram](https://github.com/user-attachments/assets/24d1dfeb-97b3-401a-95af-4c63b13b6ef9)

1. ```ChatMessagingController.sendChatMessage()```에서 클라이언트 요청을 받는다. 이때 ```ChatMessageSendRequestDto.content```의 타입은 ```Object```이고, 인스턴스는 ```Map``` 객체이다 (구현체는 ```LinkedHashMap```일 것이다). ```Map``` 객체를 위에서 언급한 ChatMessageContent 객체 중 하나로 변환해야 하는데, 이는 나중에 ```AbstractChatMessageProcessorDelegator```에서 ```ObjectMapper```를 통해 이루어진다.
2. ```ChatMessagingController```에서 ```ChatService```의 메소드 중 ```sendMessage()``` 메소드를 호출한다. ```ChatService```에서 메시지 전송 로직을 직접 처리하지 않고, ```ChatMessageProcessor``` 구현체에 메시지 전송 로직 책임을 전가한다. ```ChatMessageProcessor``` 구현체 중 유일하게 스프링 빈으로 등록된 것은 ```DelegatingChatMessageProcessorBean```이므로 ```ChatService```에 wiring되는 ```ChatMessageProcessor``` 구현체는 ```DelegatingChatMessageProcessorBean```이다.
3. ```DelegatingChatMessageProcessorBean```은 ```ChatMessageType```에 따라 적절하게 채팅 메세지를 처리할 수 있는 ```ChatMessageProcessor```에게 채팅 메시지 처리를 맡긴다.
4. 실제 채팅 메시지를 처리하는 로직을 구현한 객체는 모두 ```AbstractChatMessageProcessorDelegator```를 상속받는데, ```AbstractChatMessageProcessorDelegator.sendMessage()``` 메소드에서는 인자로 전달받은 ```ChatMessageSendRequestDto<Object>```를 ```ObjectMapper```를 활용하여 적절한 객체로 변환하고 ```processSendingMessage()``` 메소드를 호출한다. 이때 ```ObjectMapper```가 적절히 객체를 변환할 수 있도록 ```TypeReference```를 ```ObjectMapper.convertValue()``` 메소드에 전달해야 하는데, 어떤 ```TypeReference```를 전달할지는 ```AbstractChatMessageProcessorDelegator```를 상속받은 객체에서 정의하고 있다.
5. ```AbstractChatMessageProcessorDelegator```를 상속받은 객체들은 메시지 타입에 맞게 비즈니스 로직을 처리한다. 이때 ```ChatMessageRepository```를 사용해 채팅 메시지 엔티티를 DB에 저장한다. 추가로 매칭과 관련된 채팅 메시지의 경우, ```MatchingService```에 대한 의존성을 가지고 있으며, 채팅 메시지를 처리하는 동시에 매칭을 신청하거나, 매칭 신청을 거절하는 로직을 추가로 수행한다.
6. 채팅 메시지 전송 비즈니스 로직을 마친 후, 그 결과 DTO를 해당 엔드포인트에 구독하고 있는 클라이언트에게 전달한다.

```TestChatMessagingController```의 테스트 내용을 참고해 보시면 좋을 듯합니다