### PR TITLE
fix: 회원 프로필 조회 시 버그 수정

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/controller/MemberController.java
@@ -344,34 +344,28 @@ public class MemberController {
                                                             "description": ""
                                                         }
                                                     ],
-                                                    "reviews": [
-                                                        {
-                                                            "evaluationType": "GOOD",
-                                                            "reviewDetailsPerEvaluationType": [
-                                                                {
-                                                                    "reviewDetailId": 1,
-                                                                    "reviewDetailCount": 12
-                                                                },
-                                                                {
-                                                                    "reviewDetailId": 2,
-                                                                    "reviewDetailCount": 9
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "evaluationType": "NOT_GOOD",
-                                                            "reviewDetailsPerEvaluationType": [
-                                                                {
-                                                                    "reviewDetailId": 3,
-                                                                    "reviewDetailCount": 8
-                                                                },
-                                                                {
-                                                                    "reviewDetailId": 1,
-                                                                    "reviewDetailCount": 5
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
+                                                    "reviews": {
+                                                        "good": [
+                                                            {
+                                                                "reviewDetailId": 1,
+                                                                "reviewDetailCount": 12
+                                                            },
+                                                            {
+                                                                "reviewDetailId": 2,
+                                                                "reviewDetailCount": 9
+                                                            }
+                                                        ],
+                                                        "notGood": [
+                                                            {
+                                                                "reviewDetailId": 3,
+                                                                "reviewDetailCount": 8
+                                                            },
+                                                            {
+                                                                "reviewDetailId": 1,
+                                                                "reviewDetailCount": 5
+                                                            }
+                                                        ]
+                                                    },
                                                     "averageReviewScore": 3.5
                                                 }
                                             }

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/request/MemberUpdateRequestDto.java
@@ -21,6 +21,10 @@ import java.util.List;
 @BeanMapping(MemberUpdateDto.class)
 public class MemberUpdateRequestDto {
 
+    @Schema(description = "변경할 닉네임")
+    @Length(min = 1, max = 8)
+    private String nickname;
+
     @Schema(description = "회원이 현재 위치하고 있는 시/도 id")
     @Length(min = 2, max = 2)
     private String cd1;

--- a/src/main/java/com/hf/healthfriend/domain/member/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/response/ProfileResponseDto.java
@@ -13,7 +13,7 @@ public record ProfileResponseDto(
 //        Long wishedCount,
         String introduction,
         List<SpecDto> specs,
-        List<SimpleReviewResponseDto> reviews,
+        SimpleReviewResponseDto reviews,
         Double averageReviewScore
 ) {
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/MemberRepository.java
@@ -24,7 +24,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
 
     @Transactional
     @Modifying // 조회가 아닌 변경성 작업에는 해당 어노테이션을 붙여줘야 함
-    @Query(value = "UPDATE Members m SET m.review_score=:reviewScore WHERE m.member_id=:memberId ", nativeQuery = true)
+    @Query(value = "UPDATE members m SET m.review_score=:reviewScore WHERE m.member_id=:memberId ", nativeQuery = true)
     void updateMemberReviewScore(@Param("memberId")long memberId, @Param("reviewScore")double reviewScore);
 
 

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/dto/MemberUpdateDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/dto/MemberUpdateDto.java
@@ -17,6 +17,9 @@ import java.time.LocalDate;
 @BeanMapping(Member.class)
 public class MemberUpdateDto {
 
+    @MappingAttribute(target = "nickname", setNull = false)
+    private String nickname;
+
     @MappingAttribute(target = "profileImageUrl", setNull = false)
     private String profileImageUrl;
 

--- a/src/main/java/com/hf/healthfriend/domain/member/repository/querydsl/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/repository/querydsl/MemberCustomRepositoryImpl.java
@@ -221,6 +221,17 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
             log.warn("findProfileByMemberId - 쿼리 결과 리스트의 사이즈가 1을 초과합니다.");
             result.forEach((r) -> log.warn("memberId={}", r.memberId()));
         }
-        return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
+
+        return result.isEmpty() ? Optional.empty() : Optional.of(removeNull(result.get(0)));
+    }
+
+    private ProfileQueryResultDto removeNull(ProfileQueryResultDto dto) {
+        for (int i = 0; i < dto.specs().size(); i++) {
+            SpecDto specDto = dto.specs().get(i);
+            if (specDto.getSpecId() == null) {
+                dto.specs().remove(i--);
+            }
+        }
+        return dto;
     }
 }

--- a/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/service/MemberService.java
@@ -144,7 +144,7 @@ public class MemberService {
         }
     }
 
-    public List<MemberRecommendResponse> recommendMember(MembersRecommendRequest request, int pageNumber){
+    public List<MemberRecommendResponse> recommendMember(MembersRecommendRequest request, int pageNumber) {
         Pageable pageable = PageRequest.of(pageNumber - 1, 6);
         return memberRepository.recommendMembers(request, pageable);
     }
@@ -170,10 +170,9 @@ public class MemberService {
                 .memberId(profileResult.memberId())
                 .introduction(profileResult.introduction())
                 .specs(profileResult.specs())
-                .reviews(reviewDto.reviewDetails()
-                        .stream()
-                        .map((r) -> new SimpleReviewResponseDto(r.evaluationType(), r.reviewDetailsPerEvaluationType()))
-                        .toList())
+                .reviews(new SimpleReviewResponseDto(
+                        reviewDto.good().reviewDetailsPerEvaluationType(),
+                        reviewDto.notGood().reviewDetailsPerEvaluationType()))
                 .averageReviewScore(profileResult.averageReviewScore())
                 .build();
     }

--- a/src/main/java/com/hf/healthfriend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/controller/ReviewController.java
@@ -130,40 +130,37 @@ public class ReviewController {
                                                 "content": {
                                                     "memberId": 10000,
                                                     "averageScore": 3.5,
-                                                    "reviewDetails": [
-                                                        {
-                                                            "evaluationType": "GOOD",
-                                                            "totalCountPerEvaluationType": 71,
-                                                            "reviewDetailsPerEvaluationType": [
-                                                                {
-                                                                    "reviewDetailId": 3,
-                                                                    "reviewDetailCount": 36
-                                                                },
-                                                                {
-                                                                    "reviewDetailId": 1,
-                                                                    "reviewDetailCount": 23
-                                                                },
-                                                                {
-                                                                    "reviewDetailId": 2,
-                                                                    "reviewDetailCount": 12
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "evaluationType": "NOT_GOOD",
-                                                            "totalCountPerEvaluationType": 15,
-                                                            "reviewDetailsPerEvaluationType": [
-                                                                {
-                                                                    "reviewDetailId": 2,
-                                                                    "reviewDetailCount": 10
-                                                                },
-                                                                {
-                                                                    "reviewDetailId": 1,
-                                                                    "reviewDetailCount": 5
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
+                                                    "good": {
+                                                        "totalCountPerEvaluationType": 71,
+                                                        "reviewDetailsPerEvaluationType": [
+                                                            {
+                                                                "reviewDetailId": 3,
+                                                                "reviewDetailCount": 36
+                                                            },
+                                                            {
+                                                                "reviewDetailId": 1,
+                                                                "reviewDetailCount": 23
+                                                            },
+                                                            {
+                                                                "reviewDetailId": 2,
+                                                                "reviewDetailCount": 12
+                                                            }
+                                                        ]
+                                                    },
+                                                    "notGood": {
+                                                        "totalCountPerEvaluationType": 15,
+                                                        "reviewDetailsPerEvaluationType": [
+                                                            {
+                                                                "reviewDetailId": 2,
+                                                                "reviewDetailCount": 10
+                                                            },
+                                                            {
+                                                                "reviewDetailId": 1,
+                                                                "reviewDetailCount": 5
+                                                            }
+                                                        ]
+                                                    },
+                                                    "reviewScore": 3.5
                                                 }
                                             }
                                             """)

--- a/src/main/java/com/hf/healthfriend/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/dto/response/ReviewResponseDto.java
@@ -1,11 +1,8 @@
 package com.hf.healthfriend.domain.review.dto.response;
 
-import com.hf.healthfriend.domain.review.constants.EvaluationType;
-
 import java.util.List;
 
 public record ReviewResponseDto(
-        EvaluationType evaluationType,
         Long totalCountPerEvaluationType,
         List<ReviewDetailPerEvaluationType> reviewDetailsPerEvaluationType
 ) {

--- a/src/main/java/com/hf/healthfriend/domain/review/dto/response/RevieweeResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/dto/response/RevieweeResponseDto.java
@@ -1,9 +1,8 @@
 package com.hf.healthfriend.domain.review.dto.response;
 
-import java.util.List;
-
 public record RevieweeResponseDto(
         Long memberId,
-        List<ReviewResponseDto> reviewDetails
+        ReviewResponseDto good,
+        ReviewResponseDto notGood
 ) {
 }

--- a/src/main/java/com/hf/healthfriend/domain/review/dto/response/RevieweeResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/dto/response/RevieweeResponseDto.java
@@ -3,6 +3,7 @@ package com.hf.healthfriend.domain.review.dto.response;
 public record RevieweeResponseDto(
         Long memberId,
         ReviewResponseDto good,
-        ReviewResponseDto notGood
+        ReviewResponseDto notGood,
+        double averageScore
 ) {
 }

--- a/src/main/java/com/hf/healthfriend/domain/review/dto/response/SimpleReviewResponseDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/dto/response/SimpleReviewResponseDto.java
@@ -1,11 +1,9 @@
 package com.hf.healthfriend.domain.review.dto.response;
 
-import com.hf.healthfriend.domain.review.constants.EvaluationType;
-
 import java.util.List;
 
 public record SimpleReviewResponseDto(
-        EvaluationType evaluationType,
-        List<ReviewDetailPerEvaluationType> reviewDetailsPerEvaluationType
+        List<ReviewDetailPerEvaluationType> good,
+        List<ReviewDetailPerEvaluationType> notGood
 ) {
 }

--- a/src/main/java/com/hf/healthfriend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/service/ReviewService.java
@@ -164,9 +164,12 @@ public class ReviewService {
             reviewResponseDtoByEvaluationType.put(entry1.getKey(),
                     new ReviewResponseDto(totalCountPerEvaluationType, reviewDetailsPerEvaluationType));
         }
+
+        double averageScore = this.reviewRepository.calculateAverageScoreByRevieweeId(revieweeId);
         return new RevieweeResponseDto(revieweeId,
                 reviewResponseDtoByEvaluationType.get(EvaluationType.GOOD),
-                reviewResponseDtoByEvaluationType.get(EvaluationType.NOT_GOOD));
+                reviewResponseDtoByEvaluationType.get(EvaluationType.NOT_GOOD),
+                averageScore);
     }
 
     private void updateMemberReviewScore(Long revieweeId) {

--- a/src/main/java/com/hf/healthfriend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/hf/healthfriend/domain/review/service/ReviewService.java
@@ -151,7 +151,7 @@ public class ReviewService {
             countByEvaluationId.put(mapping.getEvaluationDetailId(), mapping.getEvaluationDetailCount());
         }
 
-        List<ReviewResponseDto> reviewResponseDtos = new ArrayList<>();
+        Map<EvaluationType, ReviewResponseDto> reviewResponseDtoByEvaluationType = new HashMap<>();
         for (Map.Entry<EvaluationType, Map<Integer, Long>> entry1 : evaluationDetailCountsByEvaluationType.entrySet()) {
             List<ReviewDetailPerEvaluationType> reviewDetailsPerEvaluationType = new ArrayList<>();
             long totalCountPerEvaluationType = 0L;
@@ -161,15 +161,12 @@ public class ReviewService {
                 ));
                 totalCountPerEvaluationType += entry2.getValue();
             }
-            reviewResponseDtos.add(
-                    new ReviewResponseDto(
-                            entry1.getKey(),
-                            totalCountPerEvaluationType,
-                            reviewDetailsPerEvaluationType
-                    )
-            );
+            reviewResponseDtoByEvaluationType.put(entry1.getKey(),
+                    new ReviewResponseDto(totalCountPerEvaluationType, reviewDetailsPerEvaluationType));
         }
-        return new RevieweeResponseDto(revieweeId, reviewResponseDtos);
+        return new RevieweeResponseDto(revieweeId,
+                reviewResponseDtoByEvaluationType.get(EvaluationType.GOOD),
+                reviewResponseDtoByEvaluationType.get(EvaluationType.NOT_GOOD));
     }
 
     private void updateMemberReviewScore(Long revieweeId) {

--- a/src/test/java/com/hf/healthfriend/domain/member/controller/MemberControllerMockMvcTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/controller/MemberControllerMockMvcTest.java
@@ -11,7 +11,6 @@ import com.hf.healthfriend.domain.member.exception.DuplicateMemberCreationExcept
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
 import com.hf.healthfriend.domain.member.service.MemberService;
-import com.hf.healthfriend.domain.review.constants.EvaluationType;
 import com.hf.healthfriend.domain.review.dto.response.ReviewDetailPerEvaluationType;
 import com.hf.healthfriend.domain.review.dto.response.SimpleReviewResponseDto;
 import com.hf.healthfriend.domain.spec.dto.SpecDto;
@@ -213,8 +212,8 @@ class MemberControllerMockMvcTest {
     @Test
     void memberCreation_failure() throws Exception {
         this.mockMvc.perform(post("/hf/members")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                                 {
                                     "id": "duplicate@gmail.com",
                                     "name": "김샘플",
@@ -396,27 +395,21 @@ class MemberControllerMockMvcTest {
                                 )
                         )
                         .reviews(
-                                List.of(
-                                        new SimpleReviewResponseDto(
-                                                EvaluationType.GOOD,
-                                                List.of(
-                                                        new ReviewDetailPerEvaluationType(
-                                                                1, 12L
-                                                        ),
-                                                        new ReviewDetailPerEvaluationType(
-                                                                2, 9L
-                                                        )
+                                new SimpleReviewResponseDto(
+                                        List.of(
+                                                new ReviewDetailPerEvaluationType(
+                                                        1, 12L
+                                                ),
+                                                new ReviewDetailPerEvaluationType(
+                                                        2, 9L
                                                 )
                                         ),
-                                        new SimpleReviewResponseDto(
-                                                EvaluationType.NOT_GOOD,
-                                                List.of(
-                                                        new ReviewDetailPerEvaluationType(
-                                                                3, 8L
-                                                        ),
-                                                        new ReviewDetailPerEvaluationType(
-                                                                1, 5L
-                                                        )
+                                        List.of(
+                                                new ReviewDetailPerEvaluationType(
+                                                        3, 8L
+                                                ),
+                                                new ReviewDetailPerEvaluationType(
+                                                        1, 5L
                                                 )
                                         )
                                 )
@@ -463,34 +456,28 @@ class MemberControllerMockMvcTest {
                                 "description": ""
                               }
                             ],
-                            "reviews": [
-                              {
-                                "evaluationType": "GOOD",
-                                "reviewDetailsPerEvaluationType": [
-                                  {
-                                    "reviewDetailId": 1,
-                                    "reviewDetailCount": 12
-                                  },
-                                  {
-                                    "reviewDetailId": 2,
-                                    "reviewDetailCount": 9
-                                  }
-                                ]
-                              },
-                              {
-                                "evaluationType": "NOT_GOOD",
-                                "reviewDetailsPerEvaluationType": [
-                                  {
-                                    "reviewDetailId": 3,
-                                    "reviewDetailCount": 8
-                                  },
-                                  {
-                                    "reviewDetailId": 1,
-                                    "reviewDetailCount": 5
-                                  }
-                                ]
-                              }
-                            ],
+                            "reviews": {
+                              "good": [
+                                {
+                                  "reviewDetailId": 1,
+                                  "reviewDetailCount": 12
+                                },
+                                {
+                                  "reviewDetailId": 2,
+                                  "reviewDetailCount": 9
+                                }
+                              ],
+                              "notGood": [
+                                {
+                                  "reviewDetailId": 3,
+                                  "reviewDetailCount": 8
+                                },
+                                {
+                                  "reviewDetailId": 1,
+                                  "reviewDetailCount": 5
+                                }
+                              ]
+                            },
                             "averageReviewScore": 3.5
                           }
                         }

--- a/src/test/java/com/hf/healthfriend/domain/member/repository/MemberCustomRepositoryImlTest.java
+++ b/src/test/java/com/hf/healthfriend/domain/member/repository/MemberCustomRepositoryImlTest.java
@@ -14,6 +14,8 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import java.time.LocalDate;
 import java.util.ArrayList;
+
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ActiveProfiles("test")
 @Import(TestConfig.class)
 @DataJpaTest
+@Slf4j
 public class MemberCustomRepositoryImlTest {
 
     @Autowired
@@ -167,5 +170,12 @@ public class MemberCustomRepositoryImlTest {
 
         // Then
         assertThat(result).isNotEmpty();
+
+        ProfileQueryResultDto profileQueryResultDto = result.get();
+
+        log.info("result={}", profileQueryResultDto);
+
+        assertThat(profileQueryResultDto.specs()).isEmpty();
+        assertThat(profileQueryResultDto.averageReviewScore()).isZero();
     }
 }

--- a/src/test/java/com/hf/healthfriend/domain/review/service/TestReviewService.java
+++ b/src/test/java/com/hf/healthfriend/domain/review/service/TestReviewService.java
@@ -8,6 +8,7 @@ import com.hf.healthfriend.domain.member.constant.FitnessLevel;
 import com.hf.healthfriend.domain.member.entity.Member;
 import com.hf.healthfriend.domain.member.exception.MemberNotFoundException;
 import com.hf.healthfriend.domain.member.repository.MemberRepository;
+import com.hf.healthfriend.domain.notification.service.NotificationPublishService;
 import com.hf.healthfriend.domain.review.constants.EvaluationType;
 import com.hf.healthfriend.domain.review.dto.request.ReviewCreationRequestDto;
 import com.hf.healthfriend.domain.review.dto.request.ReviewEvaluationDto;
@@ -55,6 +56,9 @@ class TestReviewService {
 
     @Mock
     MemberRepository memberRepository;
+
+    @Mock
+    NotificationPublishService notificationPublishService;
 
     Map<Long, Member> dummyMembers;
     Map<Long, Matching> dummyMatchings;
@@ -191,10 +195,10 @@ class TestReviewService {
                                 EvaluationType.GOOD, 2, 1L
                         ),
                         new RevieweeStatisticsQueryResultDto(
-                                EvaluationType.GOOD, 1, 2L
+                                EvaluationType.NOT_GOOD, 1, 2L
                         ),
                         new RevieweeStatisticsQueryResultDto(
-                                EvaluationType.GOOD, 2, 1L
+                                EvaluationType.NOT_GOOD, 2, 1L
                         )
                 ));
 
@@ -218,15 +222,31 @@ class TestReviewService {
         log.info("result={}", result);
 
         assertThat(result.memberId()).isEqualTo(reviewee.getId());
-        result.reviewDetails().forEach((re) -> {
-            assertThat(re.totalCountPerEvaluationType()).isEqualTo(3L);
-            Map<Integer, Long> counts = expectedMap.get(re.evaluationType());
-            assertThat(counts).isNotNull();
-            counts.forEach((k, v) -> {
-                Long expectedCount = counts.get(k);
-                assertThat(expectedCount).isNotNull();
-                assertThat(expectedCount).isEqualTo(v);
-            });
+        assertThat(result.good().totalCountPerEvaluationType()).isEqualTo(3L);
+        Map<Integer, Long> goodCounts = expectedMap.get(EvaluationType.GOOD);
+        assertThat(goodCounts).isNotNull();
+        goodCounts.forEach((expectedReviewDetailId, expectedCount) -> {
+            assertThat(expectedCount).isNotNull();
+            Long count = result.good().reviewDetailsPerEvaluationType()
+                    .stream()
+                    .filter((r) -> r.reviewDetailId().equals(expectedReviewDetailId))
+                    .findAny()
+                    .get()
+                    .reviewDetailCount();
+            assertThat(count).isEqualTo(expectedCount);
+        });
+        assertThat(result.notGood().totalCountPerEvaluationType()).isEqualTo(3L);
+        Map<Integer, Long> notGoodCounts = expectedMap.get(EvaluationType.NOT_GOOD);
+        assertThat(notGoodCounts).isNotNull();
+        notGoodCounts.forEach((expectedReviewDetailId, expectedCount) -> {
+            assertThat(expectedCount).isNotNull();
+            Long count = result.notGood().reviewDetailsPerEvaluationType()
+                    .stream()
+                    .filter((r) -> r.reviewDetailId().equals(expectedReviewDetailId))
+                    .findAny()
+                    .get()
+                    .reviewDetailCount();
+            assertThat(count).isEqualTo(expectedCount);
         });
     }
 }


### PR DESCRIPTION
# 개요
- 회원 프로필 조회 시 버그 수정
  - 회원 프로필 조회 시 경력 및 이력 사항이 없으면 빈 배열 혹은 null이 반환되어야 하는데, 모든 필드가 null인 객체 하나가 담긴 배열이 반환됨
- 닉네임 변경 가능
- 리뷰 조회 시 ```EvaluationType```에 따른 리뷰를 배열에 담는 대신에 "good"과 "notGood" 필드에 담아서 반환