### PR TITLE
fix: 검색 CORS 허용

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/search/controller/SearchController.java
+++ b/src/main/java/com/hf/healthfriend/domain/search/controller/SearchController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,7 @@ public class SearchController {
             @ApiResponse(responseCode = "400", description = "통합 검색 목록 조회 실패")
     })
     @GetMapping("/search")
+    @CrossOrigin
     public ResponseEntity<ApiBasicResponse<SearchResponse>> getSearchList(
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam int size,


### PR DESCRIPTION
검색 필터링 요소가 많아지면서 브라우저에서 Preflight 요청으로 처리하며 CORS 오류가 발생한다. CORS 허용 어노테이션을 붙인다.