### PR TITLE
chore: 도커 컴포즈에서 MySQL 데이터베이스 생략

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - REDIS_HOST=redis://redis-container:6379
     networks:
       - app-network
+      - hf-net
     depends_on:
       redis:
         condition: service_started
@@ -84,6 +85,7 @@ services:
       - REDIS_HOST=redis://redis-container:6379
     networks:
       - app-network
+      - hf-net
     depends_on:
       redis:
         condition: service_started
@@ -140,3 +142,5 @@ services:
 networks:
   app-network:
     driver: bridge
+  hf-net:
+    external: true


### PR DESCRIPTION
MySQL 데이터베이스를 도커 컴포즈에서 뺌으로써 MySQL 데이터베이스 보존되도록 설정