### PR TITLE
refactor: 회원 검색 시 회원 레벨 데이터 추가

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberSearchResponse.java
+++ b/src/main/java/com/hf/healthfriend/domain/member/dto/response/MemberSearchResponse.java
@@ -1,5 +1,7 @@
 package com.hf.healthfriend.domain.member.dto.response;
 
+import com.hf.healthfriend.domain.member.constant.FitnessLevel;
+import com.hf.healthfriend.domain.member.domain.Tier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class MemberSearchResponse{
+public class MemberSearchResponse {
     private Long memberId;
     private String profileImageUrl;
     private String introduction;
@@ -25,7 +27,32 @@ public class MemberSearchResponse{
     private String fitnessEagerness;
     private String fitnessKind;
     private String fitnessObjective;
+    private Tier tier;
 
-
-
+    public MemberSearchResponse(Long memberId,
+                                String profileImageUrl,
+                                String introduction,
+                                String nickname,
+                                Long wishCount,
+                                Double reviewScore,
+                                Long matchedCount,
+                                String fitnessLevel,
+                                String companionStyle,
+                                String fitnessEagerness,
+                                String fitnessKind,
+                                String fitnessObjective) {
+        this.memberId = memberId;
+        this.profileImageUrl = profileImageUrl;
+        this.introduction = introduction;
+        this.nickname = nickname;
+        this.wishCount = wishCount;
+        this.reviewScore = reviewScore;
+        this.matchedCount = matchedCount;
+        this.fitnessLevel = fitnessLevel;
+        this.companionStyle = companionStyle;
+        this.fitnessEagerness = fitnessEagerness;
+        this.fitnessKind = fitnessKind;
+        this.fitnessObjective = fitnessObjective;
+        this.tier = Tier.create(FitnessLevel.valueOf(fitnessLevel), matchedCount);
+    }
 }


### PR DESCRIPTION
회원 데이터를 쿼리하고 MemberSearchDto로 매핑할 때 회원의 레벨을 나타내는 Tier 객체 필드에 추가