### PR TITLE
fix: 찜 삭제하기 API 수정

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/wish/controller/WishController.java
+++ b/src/main/java/com/hf/healthfriend/domain/wish/controller/WishController.java
@@ -42,10 +42,10 @@ public class WishController {
             @ApiResponse(responseCode = "200", description = "찜 삭제 성공"),
             @ApiResponse(responseCode = "400", description = "찜 삭제 실패")
     })
-    @DeleteMapping("/wish/{wishId}")
-    public ResponseEntity<ApiBasicResponse<Void>> delete(@PathVariable Long wishId) {
-        wishService.delete(wishId);
-        return ResponseEntity.ok(ApiBasicResponse.of(HttpStatus.OK));
+    @DeleteMapping("/wish")
+    public ResponseEntity<ApiBasicResponse<Void>> delete(@RequestBody WishRequestDto wishRequestDto) {
+        wishService.delete(wishRequestDto);
+        return ResponseEntity.ok(ApiBasicResponse.of(HttpStatus.OK,"찜이 삭제되었습니다."));
     }
 
     @Operation(summary = "내가 찜한 목록 조회", responses = {

--- a/src/main/java/com/hf/healthfriend/domain/wish/dto/request/WishRequestDto.java
+++ b/src/main/java/com/hf/healthfriend/domain/wish/dto/request/WishRequestDto.java
@@ -3,9 +3,11 @@ package com.hf.healthfriend.domain.wish.dto.request;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class WishRequestDto {
     @NotNull
     private Long wisherId;

--- a/src/main/java/com/hf/healthfriend/domain/wish/repository/WishRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/wish/repository/WishRepository.java
@@ -11,4 +11,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
     Optional<Wish> findByWishIdAndIsDeletedFalse(Long id);
     List<Wish> findAllByWisherIdAndIsDeletedFalse(Long memberId, Pageable pageable);
     List<Wish> findAllByWishedIdAndIsDeletedFalse(Long memberId, Pageable pageable);
+
+    Optional<Wish> findByWisherIdAndWishedIdAndIsDeletedFalse(long wisherId, long wishedId);
 }

--- a/src/main/java/com/hf/healthfriend/domain/wish/service/WishService.java
+++ b/src/main/java/com/hf/healthfriend/domain/wish/service/WishService.java
@@ -57,10 +57,13 @@ public class WishService {
         }
     }
 
-    public void delete(Long wishId){
-        Wish wish = wishRepository.findByWishIdAndIsDeletedFalse(wishId)
+    public void delete(WishRequestDto wishRequestDto){
+        long wisherId = wishRequestDto.getWisherId();
+        long wishedId = wishRequestDto.getWishedId();
+
+        Wish wish = wishRepository.findByWisherIdAndWishedIdAndIsDeletedFalse(wisherId,wishedId)
                 .orElseThrow(() -> new WishException(WishErrorCode.WISH_NOT_FOUND, HttpStatus.BAD_REQUEST,
-                        "wishId: "+wishId));
+                        "wisherId: "+wisherId+", wishedId: "+wishedId));
         wish.delete();
         Member member = wish.getWished();
         member.decrementWishedCount();


### PR DESCRIPTION
# 개요 
- 찜 삭제 API에서 파라미터를 찜 pk로 받았는데, 찜을 누른 멤버와 찜을 받은 멤버의 pk를 파라미터로 받는 것으로 변경했습니다.