### PR TITLE
fix: swagger UI 403 에러 때문에 안 나오는 거 해결

### DIFF
--- a/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/hf/healthfriend/auth/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
             "/hf/posts/*",
             "/hf/popularList",
             "/hf/list",
-            "/hf/search"
+            "/hf/search",
+            "/v3/**"
     };
 
     private final ObjectMapper objectMapper;


### PR DESCRIPTION
WHITE_LIST에서 필요 없는 엔드포인트 지우다가 지우면 안 되는 것까지 지워서 swagger ui가 안 됨
롤백