### PR TITLE
fix: 댓글 갯수 감소 로직 변경

### DIFF
--- a/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/hf/healthfriend/domain/comment/service/CommentService.java
@@ -19,7 +19,6 @@ import com.hf.healthfriend.domain.post.repository.PostRepository;
 import com.hf.healthfriend.global.file.FileUrlResolver;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -90,7 +89,7 @@ public class CommentService {
         commentJpaRepository.deleteAllReplies(commentId);
         // 부모 댓글 soft delete
         commentJpaRepository.softDeleteById(commentId);
-        postRepository.decrementCommentsCountByCommentId(commentId);
+        postRepository.decrementCommentsCountByParentCommentId(commentId);
     }
 
     public List<CommentDto> getCommentsOfPost(Long postId, CommentSortType sortType) {

--- a/src/main/java/com/hf/healthfriend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/hf/healthfriend/domain/post/repository/PostRepository.java
@@ -30,7 +30,23 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     void incrementCommentsCount(@Param("postId") Long postId);
 
     @Modifying
-    @Query("UPDATE Post p SET p.commentsCount = p.commentsCount - 1 WHERE p.postId = " +
-            "(SELECT c.post.postId FROM Comment c WHERE c.commentId = :commentId)")
-    void decrementCommentsCountByCommentId(@Param("commentId") Long commentId);
+    @Query(value = """
+    WITH RECURSIVE CommentHierarchy AS (
+        SELECT comment_id
+        FROM comment
+        WHERE comment_id = :parentId
+        UNION ALL
+        SELECT c.comment_id
+        FROM comment c
+        INNER JOIN CommentHierarchy ch ON c.parent_comment_id = ch.comment_id
+    )
+    UPDATE post
+    SET comments_count = comments_count - (
+        SELECT COUNT(*) FROM CommentHierarchy
+    )
+    WHERE post_id = (
+        SELECT post_id FROM comment WHERE comment_id = :parentId
+    )
+    """, nativeQuery = true)
+    void decrementCommentsCountByParentCommentId(@Param("parentId") Long parentId);
 }


### PR DESCRIPTION
# 개요 
- 댓글을 삭제할 때 commentCount가 부모 댓글 개수만 감소되고, 대댓글 개수는 감소되지 않는 문제가 있었습니다.
- 대댓글이 있는 댓글을 삭제할 시 대댓글을 포함해서 commentCount가 감소되도록 변경했습니다.